### PR TITLE
Beaconised VP API Specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,16 @@
 ![GitHub](https://img.shields.io/github/license/ejp-rd-vp/vp-api-specs)
 ![GitHub tag (latest by date)](https://img.shields.io/github/v/tag/vp-api-specs)
 
-> This API specifications are defined in the context of the EJPRD project.
+> This API specifications are defined in the context of the EJPRD project, complying with the latest [Beacon v2 Specification](https://github.com/ga4gh-beacon/beacon-v2).
 
 In this work we present API specifications for querying RD patient registries, biobanks and similar resources at the safe record level (i.e, resources whose available assets are described by RD patient data). Resources that implement this specification would ideally collect data based on the set of common data elements for rare diseases registration, as recommended by the European commission Joint Research Centre. In this specification, where possible, we also make use of ontological terms recommended by the CDE semantic data model group.
 
-## Specification
+## Try out the API:
+Try this API here: https://app.swaggerhub.com/apis/VM172_1/vp_individuals/v1.0#/ 
+
+# Specification
+The request and response comforms to the Beacon Reference Framework.
+## Query Endpoints
 ### individuals endpoint
 > Method : POST
 
@@ -281,13 +286,18 @@ This request is sent to a resource which does not hold information about causati
 
 This response provides a warning message within the info section advising of unsupported filters which were ignored when the query was processed by the resources query engine.    
 
-## Helpful Tools
+## Informational (GET) Endpoints
+The following endpoints respond with basic information related to this Beacon Implementation. 
+### info: Get information about the Beacon
 
-- The [Swagger Software](https://swagger.io "https://swagger.io") offers several free tools that help build APIs that are compliant with the OpenAPI specification:
+### service-info: Get this Beacon's basic metadata concerning its service based on the [reference specification](https://github.com/ga4gh-discovery/ga4gh-service-info/).
 
-  - [Swagger Editor](https://swagger.io/tools/swagger-editor/ "https://swagger.io/tools/swagger-editor/") can be used to build valid API calls.
-  - [Swagger Inspector](https://inspector.swagger.io/builder "https://inspector.swagger.io/builder") is a browser extension that can be used to validate API calls.
-  
-- [OpenAPI Examples](https://github.com/OAI/OpenAPI-Specification/tree/master/examples "https://github.com/OAI/OpenAPI-Specification/tree/master/examples")
+### configuration: Get Beacon Configuration
+
+### entry_types: Get list of entry types in this Beacon
+
+### filtering_terms: Get information about available individual filtters for this beacon's entry types. 
+
+### map: Get the Beacon map with information related to the list of endpoints included in this Beacon instance.
 
 

--- a/README.md
+++ b/README.md
@@ -66,11 +66,11 @@ This specification defines POST endpoints (aka Query Endpoints) to request infor
         <td>any HGNC gene symbol</td>
     </tr>
     <tr>
-      <td><b>Age this year</b></td><td>obo:NCIT_C68615</td>
+      <td><b>Age this year</b></td><td>obo:NCIT_C83164</td>
         <td>Numerical</td>
-        <td>NCIT_C68615 </td>
+        <td>NCIT_C83164 </td>
         <td>=, &gt;=, &gt;, &lt;=, &lt;</td>
-        <td>any integer</td>
+        <td>any birth year as an integer</td>
     </tr>
     <tr>
       <td><b>Symptom Onset</b></td><td>obo:NCIT_C124353</td>

--- a/README.md
+++ b/README.md
@@ -2,40 +2,21 @@
 ![GitHub](https://img.shields.io/github/license/ejp-rd-vp/vp-api-specs)
 ![GitHub tag (latest by date)](https://img.shields.io/github/v/tag/vp-api-specs)
 
-> This API specifications are defined in the context of the EJPRD project, complying with the latest [Beacon v2 Specification](https://github.com/ga4gh-beacon/beacon-v2).
+> This API specification is defined in the context of the EJPRD project, complying with the latest [Beacon v2 Specification](https://github.com/ga4gh-beacon/beacon-v2).
 
-In this work we present API specifications for querying RD patient registries, biobanks and similar resources at the safe record level (i.e, resources whose available assets are described by RD patient data). Resources that implement this specification would ideally collect data based on the set of common data elements for rare diseases registration, as recommended by the European commission Joint Research Centre. In this specification, where possible, we also make use of ontological terms recommended by the CDE semantic data model group.
+In this work, we present API specification for querying RD patient registries, biobanks and similar resources at the safe record level (i.e, resources whose available assets are described by RD patient data). Resources that implement this specification would ideally collect data based on the set of common data elements for rare diseases registration, as recommended by the European commission Joint Research Centre. In this specification, where possible, we also make use of ontological terms recommended by the CDE semantic data model group.
 
 ## Try out the API:
-Try this API here: https://app.swaggerhub.com/apis/VM172_1/vp_individuals/v1.0#/ 
+See this API come to life in Swagger here: https://app.swaggerhub.com/apis/VM172_1/vp_individuals/v1.0#/ 
 
 # Specification
-The request and response comforms to the Beacon Reference Framework.
-## Query Endpoints
-### individuals endpoint
-> Method : POST
+The request and response conforms to the Beacon Reference Framework. This Specification defines two types of endpoints - **The Informational Endpoints** and **The Query Endpoints**. 
 
-[/individuals](https://github.com/rini21/vp-api-specs-beaconised/blob/main/individuals_api.yml) endpoint returns the count of individuals from a RD resource. This endpoint specification is drafted based on [beacon-v2 API specification](https://github.com/ga4gh-beacon/beacon-v2). The request can also contain filters which are CDE based filter parameters to filter individuals. These filters are provided as a part of request body. An example filters json is shown below.
+Informational Endpoints are simple GET requests without needing a request body, and respond with information relavant to this Beacon Specification. These are: /info, /configuration, /entry_types, /filtering_terms and /map. A special /service-info endpoint (also a GET request), responds with metadata relevant to this Beacon using the [GA4GH ServiceInfo format](https://github.com/ga4gh-discovery/ga4gh-service-info/). 
 
-```JSON
-"query": {
-      "description": "Query to get count of female (obo:NCIT_C16576) individuals with diagnostic opinion (sio:SIO_001003)  marfan syndrome (ordo:Orphanet_558)",
-      "filters": [
-        {
-          "type": "obo:NCIT_C28421",
-          "id": "obo:NCIT_C16576",
-          "operator": "="
-        },
-        {
-          "type": "sio:SIO_001003",
-          "id": "ordo:Orphanet_558",
-          "operator": "="
-        }
-      ]
-    }
-```   
+This specification defines a POST endpoint (aka Query Endpoint) to request resources relating to individuals. The /individuals endpoint makes use of the [Filters](http://docs.genomebeacons.org/filters/) capability of Beacon API, and the following filters are to be used to query resources:
 
-##### List of filters and permitted values
+<h5 id="filters_table"> List of filters and permitted values </h5>
 <table>
 <thead>
   <tr>
@@ -120,6 +101,73 @@ The request and response comforms to the Beacon Reference Framework.
   </tr>
 </tbody>
 </table>
+
+The request body and response format are described [here](#request_body).
+
+More details on Informational Endpoints [here](#info) and Query Endpoints [here](#query).
+
+Since the specification allows for record level queries of individuals, you would have to send the request using an [API Key for request authentication](#auth_header) in the header of the request.
+
+<h2 id="query">Query Endpoints</h2>
+
+### individuals endpoint
+> Method : POST
+
+[/individuals](https://github.com/rini21/vp-api-specs-beaconised/blob/main/individuals_api.yml) endpoint returns the count of individuals from a RD resource. This endpoint specification is drafted based on [beacon-v2 API specification](https://github.com/ga4gh-beacon/beacon-v2). The request can also contain filters which are CDE based filter parameters to filter individuals. These filters are provided as a part of request body. An example filter query JSON is shown below.
+
+```JSON
+"query": {
+      "description": "Query to get count of female (obo:NCIT_C16576) individuals with diagnostic opinion (sio:SIO_001003)  marfan syndrome (ordo:Orphanet_558)",
+      "filters": [
+        {
+          "type": "obo:NCIT_C28421",
+          "id": "obo:NCIT_C16576",
+          "operator": "="
+        },
+        {
+          "type": "sio:SIO_001003",
+          "id": "ordo:Orphanet_558",
+          "operator": "="
+        }
+      ]
+    }
+```   
+
+<h5 id="request_body"> Query Request Body: </h5>
+
+> Method: POST
+
+```JSON{
+  "meta": {
+    "apiVersion": "v2.0",
+    "beaconId": "Unique Beacon ID in reverse domain name notation",
+    "returnedSchemas": {
+      "entityType": "string",
+      "schema": "string"
+    }
+  },
+  "query": {
+    "filters": [
+      {
+        "type": "filter1_type",
+        "id": "filter1_value",
+        "operator": "="
+      },
+      {
+        "type": "filter2_type",
+        "id": "filter2_value",
+        "operator": "="
+      },
+      {
+        "type": "filter3_type",
+        "id": "filter3_value",
+        "operator": "="
+      },
+    ]
+  }
+}
+```
+The type of filter term **SHOULD** be one of the terms from the [filters and permitted values table](#filters_table). If any other terms are given as filter terms, the response should include a [warning message in the 'info' part](#info_response) of the response.
 
 
 ## Understanding the filters
@@ -231,7 +279,7 @@ If a user sends a query with a filter not supported by a resource then the resou
 
 The warning messages will be provided within the 'info' section of the Beacon.
 
-## Example Beacon usage with warning messages
+<h2 id="info_response"> Example Beacon usage with warning messages </h2>
 
 An example request which can be sent to a resource is shown below:
 
@@ -239,7 +287,14 @@ An example request which can be sent to a resource is shown below:
 ```JSON
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "meta":{},
+  "meta":{
+  "apiVersion": "v2.0",
+    "beaconId": "Unique Beacon ID in reverse domain name notation",
+    "returnedSchemas": {
+      "entityType": "string",
+      "schema": "string"
+    }
+  },
   "query":{
     "requestParameters": [],
     "filters": [
@@ -269,7 +324,14 @@ This request is sent to a resource which does not hold information about causati
 ```JSON
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "meta": {},
+  "meta": {
+  "apiVersion": "v2.0",
+    "beaconId": "Responding unique Beacon ID in reverse domain name notation",
+    "returnedSchemas": {
+      "entityType": "string",
+      "schema": "string"
+    }
+  },
   "responseSummary":{
     "exists": "true",
     "numTotalResults": 10
@@ -284,20 +346,34 @@ This request is sent to a resource which does not hold information about causati
 }
 ```
 
-This response provides a warning message within the info section advising of unsupported filters which were ignored when the query was processed by the resources query engine.    
+This response provides a warning message within the info section advising of unsupported filters which were ignored when the query was processed by the resources query engine. Please see the info part of [IndividualResponse](https://app.swaggerhub.com/apis/VM172_1/vp_individuals/v1.0#/IndividualResponse) schema on swagger. 
 
-## Informational (GET) Endpoints
-The following endpoints respond with basic information related to this Beacon Implementation. 
-### info: Get information about the Beacon
+<h2 id="auth_header"> Authentication using Header </h2>
+In Swagger, to query using the /individuals endpoint (which is a POST request), you have to authorize the query using the Authorize button beside available servers. 
 
-### service-info: Get this Beacon's basic metadata concerning its service based on the [reference specification](https://github.com/ga4gh-discovery/ga4gh-service-info/).
+![image](https://user-images.githubusercontent.com/24955128/203320000-a9cbc5a5-4c49-4a2b-8666-4e0cb17a5a62.png)
 
-### configuration: Get Beacon Configuration
+![image](https://user-images.githubusercontent.com/24955128/203320193-cb54791a-84f4-47fe-9bab-72a4e1dafec9.png)
 
-### entry_types: Get list of entry types in this Beacon
-
-### filtering_terms: Get information about available individual filtters for this beacon's entry types. 
-
-### map: Get the Beacon map with information related to the list of endpoints included in this Beacon instance.
+Use one of the authentication token provided to perform record level queries.
+![image](https://user-images.githubusercontent.com/24955128/203320249-ef7d1c45-e1a6-48fc-b8e5-0e3524126235.png)
 
 
+<h2 id="info"> Informational Endpoints </h2>
+
+> Method : GET
+
+The following endpoints respond with basic information related to this Beacon Implementation.
+
+##### /info: 
+Get information about the Beacon.
+##### /service-info: 
+Get this Beacon's basic metadata concerning its service, based on the [reference specification](https://github.com/ga4gh-discovery/ga4gh-service-info/).
+##### /configuration: 
+Get Beacon Configuration.
+##### /entry_types: 
+Get list of entry types in this Beacon.
+##### /filtering_terms: 
+Get information about available individual filtters for this beacon's entry types.
+##### /map: 
+Get the Beacon map with information related to the list of endpoints included in this Beacon instance.

--- a/README.md
+++ b/README.md
@@ -10,13 +10,15 @@ In this work, we present API specification for querying RD patient registries, b
 See this API come to life in Swagger [here](https://app.swaggerhub.com/apis/VM172_1/vp_individuals/v1.0#/).
 
 # Specification
-The request and response conforms to the Beacon Reference Framework. This Specification defines two types of endpoints - **The Informational Endpoints** and **The Query Endpoints**. 
+The request and response conforms to the [Beacon Reference Framework](https://github.com/ga4gh-beacon/beacon-v2). This Specification defines two types of endpoints - **The Informational Endpoints** and **The Query Endpoints**. 
 
 Informational Endpoints are simple GET requests without needing a request body, and respond with information relavant to this Beacon Specification. These are: /info, /configuration, /entry_types, /filtering_terms and /map. A special /service-info endpoint (also a GET request), responds with metadata relevant to this Beacon using the [GA4GH ServiceInfo format](https://github.com/ga4gh-discovery/ga4gh-service-info/). 
 
 This specification defines POST endpoints (aka Query Endpoints) to request information about resources. Each endpoint makes use of the [Filters](http://docs.genomebeacons.org/filters/) capability of Beacon API, and the following filters are to be used to query resources in EJP:
 
-<h4 id="filters_table"> List of filters and permitted values (Arrays are treated as ORs) </h4>
+<h4 id="filters_table"> List of filters and permitted values</h4>
+
+**(Arrays are treated as ORs)**
 
 <table>
     <thead><tr>
@@ -33,35 +35,35 @@ This specification defines POST endpoints (aka Query Endpoints) to request infor
         <td rowspan="4">Alphanumerical</td>
         <td rowspan="4">NCIT_C28421</td>
         <td rowspan="4">=</td>
-        <td>obo:NCIT_C16576</td>
+        <td>NCIT_C16576</td>
     </tr>
     <tr>
-        <td>obo:NCIT_C20197</td>
+        <td>NCIT_C20197</td>
     </tr>
     <tr>
-        <td>obo:NCIT_C124294</td>
+        <td>NCIT_C124294</td>
     </tr>
     <tr>
-        <td>obo:NCIT_C17998</td>
+        <td>NCIT_C17998</td>
     </tr>
     <tr>
       <td><b>Disease or Disorder</b></td><td>obo:NCIT_C2991</td>
         <td>Ontology</td>
+        <td>A single value or an array of orphanet terms. <b>e.g. Orphanet_558 or [Orphanet_558, Orphanet_773]</b></td>
         <td>NA</td>
         <td>NA</td>
-      <td>A single value or an array of orphanet terms. <b>e.g. Orphanet_558 or [Orphanet_558, Orphanet_773]</b></td>
     </tr>
     <tr>
       <td><b>Phenotype</b></td><td>sio:SIO_010056</td>
         <td>Ontology</td>
-        <td>NA</td>
-        <td>NA</td>
         <td>A single value or an array of HPO terms. <b>e.g. HP_0001251 or [HP_0001251, HP_0012250]</b></td>
+        <td>NA</td>
+        <td>NA</td>
     </tr>
     <tr>
-      <td><b>Causative Genes</b></td><td>edam:data_1153</td>
+      <td><b>Causative Genes</b></td><td>edam:data_2295</td>
         <td>Alphanumerical</td>
-        <td>data_1153 </td>
+        <td>data_2295 </td>
         <td>=</td>
         <td>any HGNC gene symbol</td>
     </tr>
@@ -116,8 +118,8 @@ This specification defines POST endpoints (aka Query Endpoints) to request infor
     <tr>
         <td>Biosamples</td>
     </tr>    
-</tbody></table>
-
+    </tbody>
+</table>
 
 
 The request body and response format are described [here](#request_body).
@@ -130,19 +132,174 @@ Since the specification allows for record level queries of individuals, addition
 
 <table>
 <thead>
-<th>header attribute</th>
-<th>header value</th>
-<th>purpose</th>
+<th>Header Attribute</th>
+<th>Header Value</th>
+<th>Purpose</th>
 </thead>
 <tbody>
-<tr><td>auth-key</td><td>token provided by resource</td><td>indicates requester is authorised (required)</td></tr>
-<tr><td>auth-token</td><td>bearer token, True, False</td><td>indicates requesting user's logged in status (optional)</td></tr>
-<tr><td>authentication-url</td><td>bearer token authentication provider</td><td>enables validation of bearer token (optional)</td></tr>
+<tr><td>auth-key</td><td>Token provided by resource</td><td>Indicates requester is authorised (required)</td></tr>
+<tr><td>auth-token</td><td>Bearer token, True, False</td><td>Indicates requesting user's logged in status (optional)</td></tr>
+<tr><td>authentication-url</td><td>Bearer token authentication provider</td><td>Enables validation of bearer token (optional)</td></tr>
 </tbody>
 </table>
 
-<b>Note:</b> presence of a bearer token is equivalent to auth-token:True
+> **Note:** Presence of a bearer token is equivalent to auth-token:True
 
+> **Note:** Implementers can provide distinct auth-keys to each requester or a single auth-key to all requesters.
+
+## Understanding the filters
+
+
+All filters are to be handled independently, see below for clarification.
+
+<table>
+<thead>
+  <tr>
+    <th>Filter</th>
+    <th>Filter description</th>
+    <th>Filter interpretation</th>
+  </tr>
+</thead>
+<tbody>
+  <tr>
+    <td>Sex</td>
+    <td>The biological sex of the patient</td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Disease or Disorder</td>
+    <td>All rare diseases that have been diagnosed within an individual, to encompase, but not distinguish between, all levels of diagnosis such as definitive, differential, provisional etc.</td>
+    <td>To be handled independently of other filters</td>
+  </tr>
+  <tr>
+    <td>Phenotype</td>
+    <td>HPO terms of all phenotypes observed within an individual</td>
+    <td>To be handled independently of other filters</td>
+  </tr>
+  <tr>
+    <td>Causative Genes</td>
+    <td>All genes which have been deemed as causative of one or more of the diagnosed rare diseased, encompassing and not distinguishing between all certainty levels of causality</td>
+    <td>To be handled independently of other filters</td>
+  </tr>
+  <tr>
+    <td>Age this year</td>
+    <td>Age at the end of the current year</td>
+    <td>-/+ 1 will be added to all age queries when executed by the query engine at the resource</td>
+  </tr>
+  <tr>
+    <td>Symptom Onset</td>
+    <td>Age at the manifestation of a rare disease</td>
+    <td>For individuals with more than one rare disease this filter will look at all age of manifestations independently. <br /> -/+ 1 will be added to all age queries when executed by the query engine at the resource</td>
+  </tr>
+  <tr>
+    <td>Age at diagnosis</td>
+    <td>Age at the diagnosis of a rare disease</td>
+    <td>For individuals with more than one rare disease this filter will look at all age of diagnosis independently. <br /> -/+ 1 will be added to all age queries when executed by the query engine at the resource</td>
+  </tr>
+  <tr>
+    <td>Available Materials</td>
+    <td>A list of what information is available about an individual</td>
+    <td></td>
+  </tr>
+</tbody>
+</table>
+
+## Understanding the query
+
+There are 3 types of Beacon query that this specification currently supports: 
+1. [Ontology Query](http://docs.genomebeacons.org/filters/#simple-curie-based-filters-query)
+2. [Alphanumerical Query](http://docs.genomebeacons.org/filters/#exact-value-query)
+3. [Numerical Query](http://docs.genomebeacons.org/filters/#numerical-value-query)
+
+<h5>Beacon queries require the use of the AND logical operator between filters:</h5>
+
+```JSON
+{
+"query": {
+      "filters": [
+        {
+          "id": "Orphanet_34587" 
+        },
+        {
+          "id": "data_2295",
+          "operator": "=",
+          "value": "LAMP2"
+        }
+      ]
+    }
+}
+```
+
+This filter is asking for individuals that have been diagnosed with Danon disease (Orphanet_34587) **and** where LAMP2 gene has been identified as causative. These filters are handled independently, this means that individuals with Danon disease where LAMP2 has been identified as a causative gene, specifically for Danon disease, will match the query. It also means that individuals with Danon disease and where LAMP2 has been identified as a causative gene for a second rare disease, other than Danon disease, will also match this query.
+
+<h5>Beacon queries using multiples of the same type of filter:</h5>
+To query for individuals with more than one instance of any of the filters you can send multiple of the same filter, such as in the below example:
+
+> Ontology Filter Example:
+
+```JSON
+{
+"query": 
+    {
+      "filters": [
+        {
+          "id": "Orphanet_34587"
+        },
+        {
+          "id": "Orphanet_1653"
+        }
+      ]
+   }
+}
+```
+This query is looking for individuals with Danon disease ("Orphanet_34587") AND Dentin dysplasia ("Orphanet_1653").
+
+> Alphanumeric Filter example: 
+
+```JSON
+{
+"query": 
+    {
+      "filters": [
+        {
+          "id": "Available Materials",
+          "operator": "=",
+          "value": "RNA sequence"          
+        },
+        {
+          "id": "Available Materials",
+          "operator": "=",
+          "value": "Whole Genome Sequence"
+        }
+      ]
+   }
+}
+```
+This query is looking if there are any individuals with RNA sequence information AND Whole Genome Sequence information available.
+
+<h5>Beacon queries using multiples values as an OR in phenotype or disease filters</h5>
+
+```JSON
+{
+"query": 
+    {
+      "filters": [
+        {
+          "id": ["Orphanet_34587","Orphanet_1653"]
+        }
+      ]
+   }
+}
+```
+This query is looking for individuals either with Danon disease (Orphanet_34587) OR Dentin dysplasia (Orphanet_1653).
+
+There are no OR operators available **between** filters with beacon queries.
+
+All of the defined filters are optional, the user can provide as many or as few as wanted and the resource does not have to implement all filters.
+
+If a user sends a query with a filter not supported by a resource, then the resource should complete the query but ignore the unsupported filter(s) and respond as usual, but with a warning noting that certain filters were ignored as they are unsupported.
+
+The warning messages will be provided within the 'info' section of the Beacon.
 
 <h2 id="query">Query Endpoints</h2>
 
@@ -150,8 +307,6 @@ Since the specification allows for record level queries of individuals, addition
 > Method : POST
 
 [/individuals](https://github.com/rini21/vp-api-specs-beaconised/blob/main/individuals_api.yml) endpoint returns the count of individuals from a RD resource. Filters are provided as a part of the request body. An example request JSON is shown below.
-
-
 
 <h5 id="request_body"> Query Request Body: </h5>
 
@@ -170,162 +325,25 @@ Since the specification allows for record level queries of individuals, addition
   "query": {
     "filters": [
       {
-        "type": "filter1_type",
-        "id": "filter1_value",
-        "operator": "="
+        "id": "filter1_id",
+        "operator": "=",
+        "value":"filter1_value"
+        
       },
       {
-        "type": "filter2_type",
-        "id": "filter2_value",
-        "operator": "="
+        "id": "filter2_id",
+        "operator": "=",
+        "value":"filter1_value"
       },
-      {
-        "type": "filter3_type",
-        "id": "filter3_value",
-        "operator": "="
-      },
+      { 
+        "id": "filter3_value"
+      }
     ]
   }
 }
 ```
-The type of filter term **SHOULD** be one of the terms from the [filters and permitted values table](#filters_table). Please note that not all resources will support all of the filters. In such cases the response should include a [warning message in the 'info' part](#info_response) indicating which requested filters are unsupported and these were not included in the query.
 
-
-## Understanding the filters
-
-
-All filters are to be handled independently, see below example for clarification.
-
-
-<table>
-<thead>
-  <tr>
-    <th>Filter</th>
-    <th>Filter description</th>
-    <th>Filter interpretation</th>
-  </tr>
-</thead>
-<tbody>
-  <tr>
-    <td>Sex</td>
-    <td>The biological sex of the patient</td>
-    <td></td>
-  </tr>
-  <tr>
-    <td>Diagnosis of the rare<br />disease</td>
-    <td>All rare diseases that have been diagnosed within an individual, to encompase, but not distinguish between, all levels of diagnosis such as definitive, differential, provisional etc.</td>
-    <td>To be handled independently of other filters</td>
-  </tr>
-  <tr>
-    <td>Phenotypes observed</td>
-    <td>HPO terms of all phenotypes observed within an individual</td>
-    <td>To be handled independently of other filters</td>
-  </tr>
-  <tr>
-    <td>Causative genes</td>
-    <td>All genes which have been deemed as causative of one or more of the diagnosed rare diseased, encompassing and not distinguishing between all certainty levels of causality</td>
-    <td>To be handled independently of other filters</td>
-  </tr>
-  <tr>
-    <td>Age this year</td>
-    <td>Age at the end of the current year</td>
-    <td>-/+ 1 will be added to all age queries when executed by the query engine at the resource</td>
-  </tr>
-  <tr>
-    <td>Age at disease <br /> manifestation</td>
-    <td>Age at the manifestation of a rare disease</td>
-    <td>For individuals with more than one rare disease this filter will look at all age of manifestations independently. <br /> -/+ 1 will be added to all age queries when executed by the query engine at the resource</td>
-  </tr>
-  <tr>
-    <td>Age at diagnosis</td>
-    <td>Age at the diagnosis of a rare disease</td>
-    <td>For individuals with more than one rare disease this filter will look at all age of diagnosis independently. <br /> -/+ 1 will be added to all age queries when executed by the query engine at the resource</td>
-  </tr>
-  <tr>
-    <td>Available materials</td>
-    <td>A list of what information is available about an individual</td>
-    <td></td>
-  </tr>
-</tbody>
-</table>
-
-## Understanding the query
-
-<h5>Beacon queries require the use of the AND logical operator between filters.</h5>
-
-```JSON
-{
-"query": {
-      "filters": [
-        {
-          "type": "sio:SIO_001003",
-          "id": "ordo:Orphanet_34587",
-          "operator": "="
-        },
-        {
-          "type": "alphanumeric",
-          "id": "LAMP2",
-          "operator": "="
-        }
-      ]
-    }
-}
-```
-
-This filter is asking for individuals which have been diagnosed with Danon disease (ordo:Orphanet_34587) and where LAMP2 gene has been identified as causative. These filters are handled independently, this means that individuals with danon disease where LAMP2 has been identified as a causative gene, specifically for Danon disease, will match the query. It also means that individuals with Danon disease and where LAMP2 has been identified as a causative gene for a second rare disease, other than Danon disease, will also match this query.
-
-<h5>Beacon queries using multiples of the same type of filter</h5>
-To query for individuals with more than one instance of any of the filters you can send multiple of the same filter, such as in the below example:
-
-```JSON
-{
-"query": 
-    {
-      "filters": [
-        {
-          "type": "sio:SIO_001003",
-          "id": "ordo:Orphanet_34587"
-        },
-        {
-          "type": "ontology",
-          "id": "ordo:Orphanet_1653"
-        }
-      ]
-   }
-}
-```
-
-This query is looking for individuals with Danon disease ("ordo:Orphanet_34587") AND Dentin dysplasia ("ordo:Orphanet_1653").
-
-
-<h5>Beacon queries using multiples values as an OR in phenotype or disease filters</h5>
-
-```JSON
-{
-"query": 
-    {
-      "filters": [
-        {
-          "type": "ontology",
-          "id": ["ordo:Orphanet_34587",""]
-        }
-      ]
-   }
-}
-```
-
-There are no OR operators available between filters with beacon queries.
-
-All of the defined filters are optional, the user can provide as many or as few as wanted and the resource does not have to implement all filters.
-
-If a user sends a query with a filter not supported by a resource then the resource should complete the query but ignore the unsupported filter(s) and respond as usual, but with a warning noting that certain filters were ignored as they are unsupported.
-
-The warning messages will be provided within the 'info' section of the Beacon.
-
-<h2 id="info_response"> Example Beacon usage with warning messages </h2>
-
-An example request which can be sent to a resource is shown below:
-
+**EXAMPLE REQUEST**
 
 ```JSON
 {
@@ -342,24 +360,82 @@ An example request which can be sent to a resource is shown below:
     "requestParameters": [],
     "filters": [
         {
-          "type": "sio:SIO_001003",
-          "id": "ordo:Orphanet_34587",
+          "id": "Orphanet_34587"
+        },
+        {
+          "id": "data_2295",
+          "value": "LAMP2",
           "operator": "="
         },
         {
-          "type": "obo:NCIT_C16612",
-          "id": "LAMP2",
-          "operator": "="
-        },
-        {
-          "type": "obo:NCIT_C28421",
-          "id": "obo:NCIT_C16576",
-          "operator": "="
+          "id": "NCIT_C28421",
+          "operator": "=",
+          "value": "NCIT_C16576"
         }
     ]
   }
 }
 ```
+
+**RESPONSE**
+
+
+```JSON
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "meta": {
+  "apiVersion": "v2.0",
+    "beaconId": "Responding unique Beacon ID in reverse domain name notation",
+    "returnedSchemas": {
+      "entityType": "string",
+      "schema": "string"
+    }
+  },
+  "responseSummary":{
+    "exists": "true",
+    "numTotalResults": 10
+  }
+}
+```
+The filter **SHOULD** be one of the terms from the [filters and permitted values table](#filters_table). Please note that not all resources will support all of the filters. In such cases the response should include a [warning message in the 'info' part](#info_response) indicating which requested filters are unsupported and these were not included in the query.
+
+
+<h2 id="info_response"> Example Beacon usage with warning messages </h2>
+
+**REQUEST**
+
+```JSON
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "meta":{
+  "apiVersion": "v2.0",
+    "beaconId": "Unique Beacon ID in reverse domain name notation",
+    "returnedSchemas": {
+      "entityType": "string",
+      "schema": "string"
+    }
+  },
+  "query":{
+    "requestParameters": [],
+    "filters": [
+        {
+          "id": "Orphanet_34587"
+        },
+        {
+          "id": "data_2295",
+          "value": "LAMP2",
+          "operator": "="
+        },
+        {
+          "id": "NCIT_C28421",
+          "operator": "=",
+          "value": "NCIT_C16576"
+        }
+    ]
+  }
+}
+```
+
 This request is asking for females with Danon disease with LAMP2 being identified as a causative gene.
 
 This request is sent to a resource which does not hold information about causative genes but does hold information about diagnoses and sex, an example response which could be returned is outlined below:
@@ -382,7 +458,7 @@ This request is sent to a resource which does not hold information about causati
   "info": {
     "warnings":{
       "unsupportedFilters": [
-        "obo:NCIT_C16612"
+        "data_2295"
       ]
     }
   }
@@ -391,9 +467,9 @@ This request is sent to a resource which does not hold information about causati
 
 This response provides a warning message within the info section advising of unsupported filters which were ignored when the query was processed by the resources query engine. Please see the info part of [IndividualResponse](https://app.swaggerhub.com/apis/VM172_1/vp_individuals/v1.0#/IndividualResponse) schema on swagger. 
 
+
 <h2 id="deprecated filters"> Deprecated Filters </h2>
 These filters are currently supported, but will be removed from from future versions of this specification
-
 
 <table>
 <thead>
@@ -481,16 +557,17 @@ These filters are currently supported, but will be removed from from future vers
 </table>
 
 
-<h2 id="auth_header"> Authentication using Header </h2>
+<h2 id="swagger_auth_header"> Authentication using Header for Swagger </h2>
 In Swagger, to query using the /individuals endpoint (which is a POST request), you have to authorize the query using the Authorize button beside available servers. 
 
 ![image](https://user-images.githubusercontent.com/24955128/203320000-a9cbc5a5-4c49-4a2b-8666-4e0cb17a5a62.png)
 
-![image](https://user-images.githubusercontent.com/24955128/203320193-cb54791a-84f4-47fe-9bab-72a4e1dafec9.png)
+![image](https://user-images.githubusercontent.com/24955128/205334330-c90f760d-5d1e-4685-8640-030787233454.png)
 
 Use one of the authentication token provided to perform record level queries.
-![image](https://user-images.githubusercontent.com/24955128/203320249-ef7d1c45-e1a6-48fc-b8e5-0e3524126235.png)
+![image](https://user-images.githubusercontent.com/24955128/205334443-fce92738-a515-4f0e-8f9f-b701561c283b.png)
 
+> Developers Note: No matter the user agent being used to query (i.e., SwaggerUI, Postman, cURL, etc.,), the authentication header **auth-key is required**. 
 
 <h2 id="info"> Informational Endpoints </h2>
 

--- a/README.md
+++ b/README.md
@@ -14,9 +14,387 @@ The request and response conforms to the Beacon Reference Framework. This Specif
 
 Informational Endpoints are simple GET requests without needing a request body, and respond with information relavant to this Beacon Specification. These are: /info, /configuration, /entry_types, /filtering_terms and /map. A special /service-info endpoint (also a GET request), responds with metadata relevant to this Beacon using the [GA4GH ServiceInfo format](https://github.com/ga4gh-discovery/ga4gh-service-info/). 
 
-This specification defines a POST endpoint (aka Query Endpoint) to request resources relating to individuals. The /individuals endpoint makes use of the [Filters](http://docs.genomebeacons.org/filters/) capability of Beacon API, and the following filters are to be used to query resources:
+This specification defines POST endpoints (aka Query Endpoints) to request information about resources. Each endpoint makes use of the [Filters](http://docs.genomebeacons.org/filters/) capability of Beacon API, and the following filters are to be used to query resources in EJP:
 
-<h5 id="filters_table"> List of filters and permitted values </h5>
+<h4 id="filters_table"> List of filters and permitted values (Arrays are treated as ORs) </h4>
+
+<table>
+    <thead><tr>
+        <th>CDE Concept</th><th>CDE Term</th>
+        <th>Beacon Filter Type</th>
+        <th>ID</th>
+        <th>Operator</th>
+        <th>Permitted Values</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+      <td rowspan="4"><b>Sex</b></td><td rowspan="4">obo:NCIT_C28421</td>
+        <td rowspan="4">Alphanumerical</td>
+        <td rowspan="4">NCIT_C28421</td>
+        <td rowspan="4">=</td>
+        <td>obo:NCIT_C16576</td>
+    </tr>
+    <tr>
+        <td>obo:NCIT_C20197</td>
+    </tr>
+    <tr>
+        <td>obo:NCIT_C124294</td>
+    </tr>
+    <tr>
+        <td>obo:NCIT_C17998</td>
+    </tr>
+    <tr>
+      <td><b>Disease or Disorder</b></td><td>obo:NCIT_C2991</td>
+        <td>Ontology</td>
+        <td>NA</td>
+        <td>NA</td>
+      <td>A single value or an array of orphanet terms. <b>e.g. Orphanet_558 or [Orphanet_558, Orphanet_773]</b></td>
+    </tr>
+    <tr>
+      <td><b>Phenotype</b></td><td>sio:SIO_010056</td>
+        <td>Ontology</td>
+        <td>NA</td>
+        <td>NA</td>
+        <td>A single value or an array of HPO terms. <b>e.g. HP_0001251 or [HP_0001251, HP_0012250]</b></td>
+    </tr>
+    <tr>
+      <td><b>Causative Genes</b></td><td>edam:data_1153</td>
+        <td>Alphanumerical</td>
+        <td>data_1153 </td>
+        <td>=</td>
+        <td>any HGNC gene symbol</td>
+    </tr>
+    <tr>
+      <td><b>Age this year</b></td><td>obo:NCIT_C68615</td>
+        <td>Numerical</td>
+        <td>NCIT_C68615 </td>
+        <td>=, &gt;=, &gt;, &lt;=, &lt;</td>
+        <td>any integer</td>
+    </tr>
+    <tr>
+      <td><b>Symptom Onset</b></td><td>obo:NCIT_C124353</td>
+        <td>Numerical</td>
+        <td>NCIT_C124353</td>
+        <td>=, &gt;=, &gt;, &lt;=, &lt;</td>
+        <td>any integer</td>
+    </tr>
+    <tr>
+      <td><b>Age at diagnosis</b></td><td>obo:NCIT_C156420</td>
+        <td>Numerical</td>
+        <td>NCIT_C156420</td>
+        <td>=, &gt;=, &gt;, &lt;=, &lt;</td>
+        <td>any integer</td>
+    </tr>
+    <tr>
+      <td rowspan="9"><b>Available Materials</b></td><td rowspan="10">NA</td>
+        <td rowspan="9">Alphanumerical</td>
+        <td rowspan="9">Available Materials</td>
+        <td rowspan="9">=</td>
+    </tr>
+    <tr>
+        <td>Whole Genome Sequence</td>
+    </tr>
+    <tr>
+        <td>Exome panel sequence</td>
+    </tr>
+    <tr>
+        <td>RNA sequence</td>
+    </tr>
+    <tr>
+        <td>Methylomics</td>
+    </tr>
+    <tr>
+        <td>Epigenomics</td>
+    </tr>
+    <tr>
+        <td>Pedigree data</td>
+    </tr>
+    <tr>
+        <td>Clinical data</td>
+    </tr>
+    <tr>
+        <td>Biosamples</td>
+    </tr>    
+</tbody></table>
+
+
+
+The request body and response format are described [here](#request_body).
+
+More details on Informational Endpoints [here](#info) and Query Endpoints [here](#query).
+
+<h2 id="auth_header"> Authentication using Header </h2>
+
+Since the specification allows for record level queries of individuals, additional information is required in the request header to verify the requester is authorised:
+
+<table>
+<thead>
+<th>header attribute</th>
+<th>header value</th>
+<th>purpose</th>
+</thead>
+<tbody>
+<tr><td>auth-key</td><td>token provided by resource</td><td>indicates requester is authorised (required)</td></tr>
+<tr><td>auth-token</td><td>bearer token, True, False</td><td>indicates requesting user's logged in status (optional)</td></tr>
+<tr><td>authentication-url</td><td>bearer token authentication provider</td><td>enables validation of bearer token (optional)</td></tr>
+</tbody>
+</table>
+
+<b>Note:</b> presence of a bearer token is equivalent to auth-token:True
+
+
+<h2 id="query">Query Endpoints</h2>
+
+### individuals endpoint
+> Method : POST
+
+[/individuals](https://github.com/rini21/vp-api-specs-beaconised/blob/main/individuals_api.yml) endpoint returns the count of individuals from a RD resource. Filters are provided as a part of the request body. An example request JSON is shown below.
+
+
+
+<h5 id="request_body"> Query Request Body: </h5>
+
+> Method: POST
+
+```JSON
+{
+  "meta": {
+    "apiVersion": "v2.0",
+    "beaconId": "Unique Beacon ID in reverse domain name notation",
+    "returnedSchemas": {
+      "entityType": "string",
+      "schema": "string"
+    }
+  },
+  "query": {
+    "filters": [
+      {
+        "type": "filter1_type",
+        "id": "filter1_value",
+        "operator": "="
+      },
+      {
+        "type": "filter2_type",
+        "id": "filter2_value",
+        "operator": "="
+      },
+      {
+        "type": "filter3_type",
+        "id": "filter3_value",
+        "operator": "="
+      },
+    ]
+  }
+}
+```
+The type of filter term **SHOULD** be one of the terms from the [filters and permitted values table](#filters_table). Please note that not all resources will support all of the filters. In such cases the response should include a [warning message in the 'info' part](#info_response) indicating which requested filters are unsupported and these were not included in the query.
+
+
+## Understanding the filters
+
+
+All filters are to be handled independently, see below example for clarification.
+
+
+<table>
+<thead>
+  <tr>
+    <th>Filter</th>
+    <th>Filter description</th>
+    <th>Filter interpretation</th>
+  </tr>
+</thead>
+<tbody>
+  <tr>
+    <td>Sex</td>
+    <td>The biological sex of the patient</td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Diagnosis of the rare<br />disease</td>
+    <td>All rare diseases that have been diagnosed within an individual, to encompase, but not distinguish between, all levels of diagnosis such as definitive, differential, provisional etc.</td>
+    <td>To be handled independently of other filters</td>
+  </tr>
+  <tr>
+    <td>Phenotypes observed</td>
+    <td>HPO terms of all phenotypes observed within an individual</td>
+    <td>To be handled independently of other filters</td>
+  </tr>
+  <tr>
+    <td>Causative genes</td>
+    <td>All genes which have been deemed as causative of one or more of the diagnosed rare diseased, encompassing and not distinguishing between all certainty levels of causality</td>
+    <td>To be handled independently of other filters</td>
+  </tr>
+  <tr>
+    <td>Age this year</td>
+    <td>Age at the end of the current year</td>
+    <td>-/+ 1 will be added to all age queries when executed by the query engine at the resource</td>
+  </tr>
+  <tr>
+    <td>Age at disease <br /> manifestation</td>
+    <td>Age at the manifestation of a rare disease</td>
+    <td>For individuals with more than one rare disease this filter will look at all age of manifestations independently. <br /> -/+ 1 will be added to all age queries when executed by the query engine at the resource</td>
+  </tr>
+  <tr>
+    <td>Age at diagnosis</td>
+    <td>Age at the diagnosis of a rare disease</td>
+    <td>For individuals with more than one rare disease this filter will look at all age of diagnosis independently. <br /> -/+ 1 will be added to all age queries when executed by the query engine at the resource</td>
+  </tr>
+  <tr>
+    <td>Available materials</td>
+    <td>A list of what information is available about an individual</td>
+    <td></td>
+  </tr>
+</tbody>
+</table>
+
+## Understanding the query
+
+<h5>Beacon queries require the use of the AND logical operator between filters.</h5>
+
+```JSON
+{
+"query": {
+      "filters": [
+        {
+          "type": "sio:SIO_001003",
+          "id": "ordo:Orphanet_34587",
+          "operator": "="
+        },
+        {
+          "type": "alphanumeric",
+          "id": "LAMP2",
+          "operator": "="
+        }
+      ]
+    }
+}
+```
+
+This filter is asking for individuals which have been diagnosed with Danon disease (ordo:Orphanet_34587) and where LAMP2 gene has been identified as causative. These filters are handled independently, this means that individuals with danon disease where LAMP2 has been identified as a causative gene, specifically for Danon disease, will match the query. It also means that individuals with Danon disease and where LAMP2 has been identified as a causative gene for a second rare disease, other than Danon disease, will also match this query.
+
+<h5>Beacon queries using multiples of the same type of filter</h5>
+To query for individuals with more than one instance of any of the filters you can send multiple of the same filter, such as in the below example:
+
+```JSON
+{
+"query": 
+    {
+      "filters": [
+        {
+          "type": "sio:SIO_001003",
+          "id": "ordo:Orphanet_34587"
+        },
+        {
+          "type": "ontology",
+          "id": "ordo:Orphanet_1653"
+        }
+      ]
+   }
+}
+```
+
+This query is looking for individuals with Danon disease ("ordo:Orphanet_34587") AND Dentin dysplasia ("ordo:Orphanet_1653").
+
+
+<h5>Beacon queries using multiples values as an OR in phenotype or disease filters</h5>
+
+```JSON
+{
+"query": 
+    {
+      "filters": [
+        {
+          "type": "ontology",
+          "id": ["ordo:Orphanet_34587",""]
+        }
+      ]
+   }
+}
+```
+
+There are no OR operators available between filters with beacon queries.
+
+All of the defined filters are optional, the user can provide as many or as few as wanted and the resource does not have to implement all filters.
+
+If a user sends a query with a filter not supported by a resource then the resource should complete the query but ignore the unsupported filter(s) and respond as usual, but with a warning noting that certain filters were ignored as they are unsupported.
+
+The warning messages will be provided within the 'info' section of the Beacon.
+
+<h2 id="info_response"> Example Beacon usage with warning messages </h2>
+
+An example request which can be sent to a resource is shown below:
+
+
+```JSON
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "meta":{
+  "apiVersion": "v2.0",
+    "beaconId": "Unique Beacon ID in reverse domain name notation",
+    "returnedSchemas": {
+      "entityType": "string",
+      "schema": "string"
+    }
+  },
+  "query":{
+    "requestParameters": [],
+    "filters": [
+        {
+          "type": "sio:SIO_001003",
+          "id": "ordo:Orphanet_34587",
+          "operator": "="
+        },
+        {
+          "type": "obo:NCIT_C16612",
+          "id": "LAMP2",
+          "operator": "="
+        },
+        {
+          "type": "obo:NCIT_C28421",
+          "id": "obo:NCIT_C16576",
+          "operator": "="
+        }
+    ]
+  }
+}
+```
+This request is asking for females with Danon disease with LAMP2 being identified as a causative gene.
+
+This request is sent to a resource which does not hold information about causative genes but does hold information about diagnoses and sex, an example response which could be returned is outlined below:
+
+```JSON
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "meta": {
+  "apiVersion": "v2.0",
+    "beaconId": "Responding unique Beacon ID in reverse domain name notation",
+    "returnedSchemas": {
+      "entityType": "string",
+      "schema": "string"
+    }
+  },
+  "responseSummary":{
+    "exists": "true",
+    "numTotalResults": 10
+  },
+  "info": {
+    "warnings":{
+      "unsupportedFilters": [
+        "obo:NCIT_C16612"
+      ]
+    }
+  }
+}
+```
+
+This response provides a warning message within the info section advising of unsupported filters which were ignored when the query was processed by the resources query engine. Please see the info part of [IndividualResponse](https://app.swaggerhub.com/apis/VM172_1/vp_individuals/v1.0#/IndividualResponse) schema on swagger. 
+
+<h2 id="deprecated filters"> Deprecated Filters </h2>
+These filters are currently supported, but will be removed from from future versions of this specification
+
+
 <table>
 <thead>
   <tr>
@@ -102,260 +480,6 @@ This specification defines a POST endpoint (aka Query Endpoint) to request resou
 </tbody>
 </table>
 
-The request body and response format are described [here](#request_body).
-
-More details on Informational Endpoints [here](#info) and Query Endpoints [here](#query).
-
-Since the specification allows for record level queries of individuals, you would have to send the request using an [API Key for request authentication](#auth_header) in the header of the request.
-
-<h2 id="query">Query Endpoints</h2>
-
-### individuals endpoint
-> Method : POST
-
-[/individuals](https://github.com/rini21/vp-api-specs-beaconised/blob/main/individuals_api.yml) endpoint returns the count of individuals from a RD resource. This endpoint specification is drafted based on [beacon-v2 API specification](https://github.com/ga4gh-beacon/beacon-v2). The request can also contain filters which are CDE based filter parameters to filter individuals. These filters are provided as a part of request body. An example filter query JSON is shown below.
-
-```JSON
-{
-"query": {
-      "description": "Query to get count of female (obo:NCIT_C16576) individuals with diagnostic opinion (sio:SIO_001003)  marfan syndrome (ordo:Orphanet_558)",
-      "filters": [
-        {
-          "type": "obo:NCIT_C28421",
-          "id": "obo:NCIT_C16576",
-          "operator": "="
-        },
-        {
-          "type": "sio:SIO_001003",
-          "id": "ordo:Orphanet_558",
-          "operator": "="
-        }
-      ]
-    }
-}
-```   
-
-<h5 id="request_body"> Query Request Body: </h5>
-
-> Method: POST
-
-```JSON
-{
-  "meta": {
-    "apiVersion": "v2.0",
-    "beaconId": "Unique Beacon ID in reverse domain name notation",
-    "returnedSchemas": {
-      "entityType": "string",
-      "schema": "string"
-    }
-  },
-  "query": {
-    "filters": [
-      {
-        "type": "filter1_type",
-        "id": "filter1_value",
-        "operator": "="
-      },
-      {
-        "type": "filter2_type",
-        "id": "filter2_value",
-        "operator": "="
-      },
-      {
-        "type": "filter3_type",
-        "id": "filter3_value",
-        "operator": "="
-      },
-    ]
-  }
-}
-```
-The type of filter term **SHOULD** be one of the terms from the [filters and permitted values table](#filters_table). If any other terms are given as filter terms, the response should include a [warning message in the 'info' part](#info_response) of the response.
-
-
-## Understanding the filters
-
-
-All filters are to be handled independently, see below example for clarification.
-
-```JSON
-{
-"query": {
-      "filters": [
-        {
-          "type": "sio:SIO_001003",
-          "id": "ordo:Orphanet_34587",
-          "operator": "="
-        },
-        {
-          "type": "obo:NCIT_C16612",
-          "id": "LAMP2",
-          "operator": "="
-        }
-      ]
-    }
-}
-```
-
-This filter is asking for individuals which have been diagnosed with Danon disease (ordo:Orphanet_34587) and where LAMP2 gene has been identified as causative. These filters are handled independently, this means that individuals with danon disease where LAMP2 has been identified as a causative gene, specifically for Danon disease, will match the query. It also means that individuals with Danon disease and where LAMP2 has been identified as a causative gene for a second rare disease, other than Danon disease, will also match this query.
-
-
-<table>
-<thead>
-  <tr>
-    <th>Filter</th>
-    <th>Filter description</th>
-    <th>Filter interpretation</th>
-  </tr>
-</thead>
-<tbody>
-  <tr>
-    <td>Sex</td>
-    <td>The biological sex of the patient</td>
-    <td></td>
-  </tr>
-  <tr>
-    <td>Diagnosis of the rare<br />disease</td>
-    <td>All rare diseases that have been diagnosed within an individual, to encompase, but not distinguish between, all levels of diagnosis such as definitive, differential, provisional etc.</td>
-    <td>To be handled independently of other filters</td>
-  </tr>
-  <tr>
-    <td>Phenotypes observed</td>
-    <td>HPO terms of all phenotypes observed within an individual</td>
-    <td>To be handled independently of other filters</td>
-  </tr>
-  <tr>
-    <td>Causative genes</td>
-    <td>All genes which have been deemed as causative of one or more of the diagnosed rare diseased, encompassing and not distinguishing between all certainty levels of causality</td>
-    <td>To be handled independently of other filters</td>
-  </tr>
-  <tr>
-    <td>Age this year</td>
-    <td>Age at the end of the current year</td>
-    <td>-/+ 1 will be added to all age queries when executed by the query engine at the resource</td>
-  </tr>
-  <tr>
-    <td>Age at disease <br /> manifestation</td>
-    <td>Age at the manifestation of a rare disease</td>
-    <td>For individuals with more than one rare disease this filter will look at all age of manifestations independently. <br /> -/+ 1 will be added to all age queries when executed by the query engine at the resource</td>
-  </tr>
-  <tr>
-    <td>Age at diagnosis</td>
-    <td>Age at the diagnosis of a rare disease</td>
-    <td>For individuals with more than one rare disease this filter will look at all age of diagnosis independently. <br /> -/+ 1 will be added to all age queries when executed by the query engine at the resource</td>
-  </tr>
-  <tr>
-    <td>Available materials</td>
-    <td>A list of what information is available about an individual</td>
-    <td></td>
-  </tr>
-</tbody>
-</table>
-
-## Understanding the query
-
-Beacon queries require the use of the AND logical operator between filters and each filter can have at most one possible value.
-
-To query for individuals with more than one instance of any of the filters you can send multiple of the same filter, such as in the below example:
-
-```JSON
-{
-"query": 
-    {
-      "filters": [
-        {
-          "type": "sio:SIO_001003",
-          "id": "ordo:Orphanet_34587",
-          "operator": "="
-        },
-        {
-          "type": "sio:SIO_001003",
-          "id": "ordo:Orphanet_1653",
-          "operator": "="
-        }
-      ]
-   }
-}
-```
-
-This query is looking for individuals with Danon disease ("ordo:Orphanet_34587") AND Dentin dysplasia ("ordo:Orphanet_1653").
-
-There are no OR operators available with beacon queries.
-
-All of the defined filters are optional, the user can provide as many or as few as wanted and the resource does not have to implement all filters.
-
-If a user sends a query with a filter not supported by a resource then the resource should complete the query but ignore the unsupported filter(s) and respond as usual, but with a warning noting that certain filters were ignored as they are unsupported.
-
-The warning messages will be provided within the 'info' section of the Beacon.
-
-<h2 id="info_response"> Example Beacon usage with warning messages </h2>
-
-An example request which can be sent to a resource is shown below:
-
-
-```JSON
-{
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "meta":{
-  "apiVersion": "v2.0",
-    "beaconId": "Unique Beacon ID in reverse domain name notation",
-    "returnedSchemas": {
-      "entityType": "string",
-      "schema": "string"
-    }
-  },
-  "query":{
-    "requestParameters": [],
-    "filters": [
-        {
-          "type": "sio:SIO_001003",
-          "id": "ordo:Orphanet_34587",
-          "operator": "="
-        },
-        {
-          "type": "obo:NCIT_C16612",
-          "id": "LAMP2",
-          "operator": "="
-        },
-        {
-          "type": "obo:NCIT_C28421",
-          "id": "obo:NCIT_C16576",
-          "operator": "="
-        }
-    ]
-  }
-}
-```
-This request is asking for females with Danon disease with LAMP2 being identified as a causative gene.
-
-This request is sent to a resource which does not hold information about causative genes but does hold information about diagnoses and sex, an example response which could be returned is outlined below:
-
-```JSON
-{
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "meta": {
-  "apiVersion": "v2.0",
-    "beaconId": "Responding unique Beacon ID in reverse domain name notation",
-    "returnedSchemas": {
-      "entityType": "string",
-      "schema": "string"
-    }
-  },
-  "responseSummary":{
-    "exists": "true",
-    "numTotalResults": 10
-  },
-  "info": {
-    "warnings":{
-      "unsupportedFilters": [
-        "obo:NCIT_C16612"
-      ]
-    }
-  }
-}
-```
-
-This response provides a warning message within the info section advising of unsupported filters which were ignored when the query was processed by the resources query engine. Please see the info part of [IndividualResponse](https://app.swaggerhub.com/apis/VM172_1/vp_individuals/v1.0#/IndividualResponse) schema on swagger. 
 
 <h2 id="auth_header"> Authentication using Header </h2>
 In Swagger, to query using the /individuals endpoint (which is a POST request), you have to authorize the query using the Authorize button beside available servers. 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 In this work, we present API specification for querying RD patient registries, biobanks and similar resources at the safe record level (i.e, resources whose available assets are described by RD patient data). Resources that implement this specification would ideally collect data based on the set of common data elements for rare diseases registration, as recommended by the European commission Joint Research Centre. In this specification, where possible, we also make use of ontological terms recommended by the CDE semantic data model group.
 
 ## Try out the API:
-See this API come to life in Swagger [here](https://app.swaggerhub.com/apis/VM172_1/vp_individuals/v1.0#/).
+Check out [version 0.1 here](https://app.swaggerhub.com/apis/VM172_1/vp_individuals/v0.1) and [version 0.2 here](https://app.swaggerhub.com/apis/VM172_1/vp_individuals/v0.2).
 
 # Specification
 The request and response conforms to the [Beacon Reference Framework](https://github.com/ga4gh-beacon/beacon-v2). This Specification defines two types of endpoints - **The Informational Endpoints** and **The Query Endpoints**. 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 In this work, we present API specification for querying RD patient registries, biobanks and similar resources at the safe record level (i.e, resources whose available assets are described by RD patient data). Resources that implement this specification would ideally collect data based on the set of common data elements for rare diseases registration, as recommended by the European commission Joint Research Centre. In this specification, where possible, we also make use of ontological terms recommended by the CDE semantic data model group.
 
 ## Try out the API:
-See this API come to life in Swagger here: https://app.swaggerhub.com/apis/VM172_1/vp_individuals/v1.0#/ 
+See this API come to life in Swagger [here](https://app.swaggerhub.com/apis/VM172_1/vp_individuals/v1.0#/).
 
 # Specification
 The request and response conforms to the Beacon Reference Framework. This Specification defines two types of endpoints - **The Informational Endpoints** and **The Query Endpoints**. 

--- a/README.md
+++ b/README.md
@@ -33,58 +33,58 @@ This specification defines POST endpoints (aka Query Endpoints) to request infor
     <tr>
       <td rowspan="4"><b>Sex</b></td><td rowspan="4">obo:NCIT_C28421</td>
         <td rowspan="4">Alphanumerical</td>
-        <td rowspan="4">NCIT_C28421</td>
+        <td rowspan="4">obo:NCIT_C28421</td>
         <td rowspan="4">=</td>
-        <td>NCIT_C16576</td>
+        <td>obo:NCIT_C16576</td>
     </tr>
     <tr>
-        <td>NCIT_C20197</td>
+        <td>obo:NCIT_C20197</td>
     </tr>
     <tr>
-        <td>NCIT_C124294</td>
+        <td>obo:NCIT_C124294</td>
     </tr>
     <tr>
-        <td>NCIT_C17998</td>
+        <td>obo:NCIT_C17998</td>
     </tr>
     <tr>
       <td><b>Disease or Disorder</b></td><td>obo:NCIT_C2991</td>
         <td>Ontology</td>
-        <td>A single value or an array of orphanet terms. <b>e.g. Orphanet_558 or [Orphanet_558, Orphanet_773]</b></td>
+        <td>A single value or an array of orphanet terms. <b>e.g. ordo:Orphanet_558 or [ordo:Orphanet_558, ordo:Orphanet_773]</b></td>
         <td>NA</td>
         <td>NA</td>
     </tr>
     <tr>
       <td><b>Phenotype</b></td><td>sio:SIO_010056</td>
         <td>Ontology</td>
-        <td>A single value or an array of HPO terms. <b>e.g. HP_0001251 or [HP_0001251, HP_0012250]</b></td>
+        <td>A single value or an array of HPO terms. <b>e.g. obo:HP_0001251 or [obo:HP_0001251, obo:HP_0012250]</b></td>
         <td>NA</td>
         <td>NA</td>
     </tr>
     <tr>
       <td><b>Causative Genes</b></td><td>edam:data_2295</td>
         <td>Alphanumerical</td>
-        <td>data_2295 </td>
+        <td>edam:data_2295 </td>
         <td>=</td>
         <td>any HGNC gene symbol</td>
     </tr>
     <tr>
       <td><b>Age this year</b></td><td>obo:NCIT_C83164</td>
         <td>Numerical</td>
-        <td>NCIT_C83164 </td>
+        <td>obo:NCIT_C83164 </td>
         <td>=, &gt;=, &gt;, &lt;=, &lt;</td>
         <td>any birth year as an integer</td>
     </tr>
     <tr>
       <td><b>Symptom Onset</b></td><td>obo:NCIT_C124353</td>
         <td>Numerical</td>
-        <td>NCIT_C124353</td>
+        <td>obo:NCIT_C124353</td>
         <td>=, &gt;=, &gt;, &lt;=, &lt;</td>
         <td>any integer</td>
     </tr>
     <tr>
       <td><b>Age at diagnosis</b></td><td>obo:NCIT_C156420</td>
         <td>Numerical</td>
-        <td>NCIT_C156420</td>
+        <td>obo:NCIT_C156420</td>
         <td>=, &gt;=, &gt;, &lt;=, &lt;</td>
         <td>any integer</td>
     </tr>
@@ -218,10 +218,10 @@ There are 3 types of Beacon query that this specification currently supports:
 "query": {
       "filters": [
         {
-          "id": "Orphanet_34587" 
+          "id": "ordo:Orphanet_34587" 
         },
         {
-          "id": "data_2295",
+          "id": "edam:data_2295",
           "operator": "=",
           "value": "LAMP2"
         }
@@ -230,7 +230,7 @@ There are 3 types of Beacon query that this specification currently supports:
 }
 ```
 
-This filter is asking for individuals that have been diagnosed with Danon disease (Orphanet_34587) **and** where LAMP2 gene has been identified as causative. These filters are handled independently, this means that individuals with Danon disease where LAMP2 has been identified as a causative gene, specifically for Danon disease, will match the query. It also means that individuals with Danon disease and where LAMP2 has been identified as a causative gene for a second rare disease, other than Danon disease, will also match this query.
+This filter is asking for individuals that have been diagnosed with Danon disease (ordo:Orphanet_34587) **and** where LAMP2 gene has been identified as causative. These filters are handled independently, this means that individuals with Danon disease where LAMP2 has been identified as a causative gene, specifically for Danon disease, will match the query. It also means that individuals with Danon disease and where LAMP2 has been identified as a causative gene for a second rare disease, other than Danon disease, will also match this query.
 
 <h5>Beacon queries using multiples of the same type of filter:</h5>
 To query for individuals with more than one instance of any of the filters you can send multiple of the same filter, such as in the below example:
@@ -243,16 +243,16 @@ To query for individuals with more than one instance of any of the filters you c
     {
       "filters": [
         {
-          "id": "Orphanet_34587"
+          "id": "ordo:Orphanet_34587"
         },
         {
-          "id": "Orphanet_1653"
+          "id": "ordo:Orphanet_1653"
         }
       ]
    }
 }
 ```
-This query is looking for individuals with Danon disease ("Orphanet_34587") AND Dentin dysplasia ("Orphanet_1653").
+This query is looking for individuals with Danon disease ("ordo:Orphanet_34587") AND Dentin dysplasia ("ordo:Orphanet_1653").
 
 > Alphanumeric Filter example: 
 
@@ -285,13 +285,13 @@ This query is looking if there are any individuals with RNA sequence information
     {
       "filters": [
         {
-          "id": ["Orphanet_34587","Orphanet_1653"]
+          "id": ["ordo:Orphanet_34587","ordo:Orphanet_1653"]
         }
       ]
    }
 }
 ```
-This query is looking for individuals either with Danon disease (Orphanet_34587) OR Dentin dysplasia (Orphanet_1653).
+This query is looking for individuals either with Danon disease (ordo:Orphanet_34587) OR Dentin dysplasia (ordo:Orphanet_1653).
 
 There are no OR operators available **between** filters with beacon queries.
 
@@ -360,17 +360,17 @@ The warning messages will be provided within the 'info' section of the Beacon.
     "requestParameters": [],
     "filters": [
         {
-          "id": "Orphanet_34587"
+          "id": "ordo:Orphanet_34587"
         },
         {
-          "id": "data_2295",
+          "id": "edam:data_2295",
           "value": "LAMP2",
           "operator": "="
         },
         {
-          "id": "NCIT_C28421",
+          "id": "obo:NCIT_C28421",
           "operator": "=",
-          "value": "NCIT_C16576"
+          "value": "obo:NCIT_C16576"
         }
     ]
   }
@@ -419,17 +419,17 @@ The filter **SHOULD** be one of the terms from the [filters and permitted values
     "requestParameters": [],
     "filters": [
         {
-          "id": "Orphanet_34587"
+          "id": "ordo:Orphanet_34587"
         },
         {
-          "id": "data_2295",
+          "id": "edam:data_2295",
           "value": "LAMP2",
           "operator": "="
         },
         {
-          "id": "NCIT_C28421",
+          "id": "obo:NCIT_C28421",
           "operator": "=",
-          "value": "NCIT_C16576"
+          "value": "obo:NCIT_C16576"
         }
     ]
   }
@@ -458,7 +458,7 @@ This request is sent to a resource which does not hold information about causati
   "info": {
     "warnings":{
       "unsupportedFilters": [
-        "data_2295"
+        "edam:data_2295"
       ]
     }
   }

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Since the specification allows for record level queries of individuals, you woul
 [/individuals](https://github.com/rini21/vp-api-specs-beaconised/blob/main/individuals_api.yml) endpoint returns the count of individuals from a RD resource. This endpoint specification is drafted based on [beacon-v2 API specification](https://github.com/ga4gh-beacon/beacon-v2). The request can also contain filters which are CDE based filter parameters to filter individuals. These filters are provided as a part of request body. An example filter query JSON is shown below.
 
 ```JSON
+{
 "query": {
       "description": "Query to get count of female (obo:NCIT_C16576) individuals with diagnostic opinion (sio:SIO_001003)  marfan syndrome (ordo:Orphanet_558)",
       "filters": [
@@ -131,13 +132,15 @@ Since the specification allows for record level queries of individuals, you woul
         }
       ]
     }
+}
 ```   
 
 <h5 id="request_body"> Query Request Body: </h5>
 
 > Method: POST
 
-```JSON{
+```JSON
+{
   "meta": {
     "apiVersion": "v2.0",
     "beaconId": "Unique Beacon ID in reverse domain name notation",
@@ -176,10 +179,11 @@ The type of filter term **SHOULD** be one of the terms from the [filters and per
 All filters are to be handled independently, see below example for clarification.
 
 ```JSON
+{
 "query": {
       "filters": [
         {
-          "type": "	sio:SIO_001003",
+          "type": "sio:SIO_001003",
           "id": "ordo:Orphanet_34587",
           "operator": "="
         },
@@ -190,6 +194,7 @@ All filters are to be handled independently, see below example for clarification
         }
       ]
     }
+}
 ```
 
 This filter is asking for individuals which have been diagnosed with Danon disease (ordo:Orphanet_34587) and where LAMP2 gene has been identified as causative. These filters are handled independently, this means that individuals with danon disease where LAMP2 has been identified as a causative gene, specifically for Danon disease, will match the query. It also means that individuals with Danon disease and where LAMP2 has been identified as a causative gene for a second rare disease, other than Danon disease, will also match this query.
@@ -254,19 +259,23 @@ Beacon queries require the use of the AND logical operator between filters and e
 To query for individuals with more than one instance of any of the filters you can send multiple of the same filter, such as in the below example:
 
 ```JSON
-"query": {
+{
+"query": 
+    {
       "filters": [
         {
-          "type": "	sio:SIO_001003",
+          "type": "sio:SIO_001003",
           "id": "ordo:Orphanet_34587",
           "operator": "="
         },
         {
-          "type": "	sio:SIO_001003",
+          "type": "sio:SIO_001003",
           "id": "ordo:Orphanet_1653",
           "operator": "="
         }
       ]
+   }
+}
 ```
 
 This query is looking for individuals with Danon disease ("ordo:Orphanet_34587") AND Dentin dysplasia ("ordo:Orphanet_1653").
@@ -299,7 +308,7 @@ An example request which can be sent to a resource is shown below:
     "requestParameters": [],
     "filters": [
         {
-          "type": "	sio:SIO_001003",
+          "type": "sio:SIO_001003",
           "id": "ordo:Orphanet_34587",
           "operator": "="
         },
@@ -312,7 +321,7 @@ An example request which can be sent to a resource is shown below:
           "type": "obo:NCIT_C28421",
           "id": "obo:NCIT_C16576",
           "operator": "="
-        },
+        }
     ]
   }
 }

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The request and response comforms to the Beacon Reference Framework.
 ### individuals endpoint
 > Method : POST
 
-[/individuals](https://github.com/ejp-rd-vp/vp-api-specs/blob/main/individuals_api.yml) endpoint returns the count of individuals from a RD resource. This endpoint specification is drafted based on [beacon-v2 API specification](https://github.com/ga4gh-beacon/beacon-v2). The request can also contain filters which are CDE based filter parameters to filter individuals. These filters are provided as a part of request body. An example filters json is shown below.
+[/individuals](https://github.com/rini21/vp-api-specs-beaconised/blob/main/individuals_api.yml) endpoint returns the count of individuals from a RD resource. This endpoint specification is drafted based on [beacon-v2 API specification](https://github.com/ga4gh-beacon/beacon-v2). The request can also contain filters which are CDE based filter parameters to filter individuals. These filters are provided as a part of request body. An example filters json is shown below.
 
 ```JSON
 "query": {

--- a/individuals_api.yml
+++ b/individuals_api.yml
@@ -164,6 +164,15 @@ components:
       description: |
         Respond with the list of available query endpoints in this Beacon.
     EntryTypesResponse:
+      required:
+      - meta
+      - response
+      type: object
+      properties: 
+        meta:
+          $ref: '#/components/schemas/MetaContent'
+        response:
+          $ref: '#/components/schemas/ETResponseContent'
       description: |
         Respond with the entry types available  in this Beacon Implementation.
     ConfigurationResponse:
@@ -241,6 +250,81 @@ components:
               type: string
               description: |
                 Name of the organization.
+    ETResponseContent:
+      required: 
+      - entryTypes
+      type: object
+      properties:
+        entryTypes:
+          required:
+          - Individuals
+          type: object
+          description: |
+            List of entry types. 
+          properties:
+            Individuals:
+              description: |
+                Definition of an element or entry type including the Beacon v2 required and suggested attributes. This schema purpose is to describe each type of entities included in this beacon, hence Beacon clients could have some metadata about such entities.
+              required: 
+              - defaultSchema
+              - id
+              - name
+              - ontologyTermForThisType
+              - partOfSpecification
+              type: object
+              properties: 
+                defaultSchema:
+                  description: |
+                    Definition of an annotated URL address or a file reference.
+                  required:
+                    - id
+                    - name
+                    - referenceToSchemaDefinition
+                  properties:
+                    id:
+                      type: string
+                      description: |
+                        A (unique) identifier of the element.
+                      example: Individuals
+                    name:
+                      type: string
+                      description: |
+                        A distinctive name for the element.
+                      example: Individuals
+                    referenceToSchemaDefinition:
+                      type: string
+                      description: |
+                        Conforming Schema of the element.
+                      example: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2-Models/main/BEACON-V2-draft4-Model/individuals/defaultSchema.json
+                id:
+                  description: |
+                    A unique identifier of the element.
+                  type: string
+                  example: Individuals
+                name: 
+                  description: |
+                    A distinctive name for the element.
+                  type: string
+                  example: Individuals
+                ontologyTermForThisType: 
+                  description: |
+                    Definition of an ontology term.
+                  type: object
+                  required:
+                  - id
+                  properties: 
+                    id: 
+                      description: |
+                        A CURIE identifier as `id` for ontology term.
+                      example: NCIT:C25190
+                      type: string
+                partOfSpecification:
+                  description: |
+                    This label is to group together entry types that are part of the same specification.
+                  type: string
+                  example: Beacon v2.0
+      description: |
+        Respond with a list of entry types conforming to Beacon v2 spec.
     IndividualResponse:
       description: |
         Response of a query over individuals counts.

--- a/individuals_api.yml
+++ b/individuals_api.yml
@@ -16,42 +16,56 @@ paths:
   /info:
     get:
       summary: "Get information regarding this beacon."
+      tags:
+      - Informational Endpoint
       responses:
         200:
           $ref: '#/components/schemas/InfoResponse'
   /filtering_terms:
     get:
       summary: "Get the valid filtering terms to be used in querying/handled by this beacon."
+      tags:
+      - Informational Endpoint
       responses:
         200:
           $ref: '#/components/schemas/FilterTermsResponse'
   /map:
     get:
       summary: "Get the list of endpoints included in this beacon i.e., individuals."
+      tags:
+      - Informational Endpoint
       responses:
         200:
           $ref: '#/components/schemas/MapResponse'
   /service-info:
     get:
       summary: "Get information about the beacon using GA4GH ServiceInfo format."
+      tags:
+      - Informational Endpoint
       responses:
         200:
           $ref: '#/components/schemas/ServiceInfoResponse'
   /configuration:
     get:
       summary: "Get the configuration of this beacon."
+      tags:
+      - Informational Endpoint
       responses:
         200:
           $ref: '#/components/schemas/ConfigurationResponse'
   /entry_types:
     get:
       summary: "Get the list of beacon entry types."
+      tags:
+      - Informational Endpoint
       responses:
         200:
           $ref: '#/components/schemas/EntryTypesResponse'
   /individuals:
     post:
       summary: "Request to retrive count of individuals from a data source (i.e. patients)"
+      tags:
+      - Query Endpoint
       operationId: individuals_request
       requestBody:
         content:

--- a/individuals_api.yml
+++ b/individuals_api.yml
@@ -1,15 +1,54 @@
 openapi: 3.0.1
 info:
-  title: Virtual platform data record APIs
+  title: Virtual platform Beacon API
   x-beaconVersion: v2.0
   description: EJPRD virtual platform data record APIs
+  contact:
+    email: admin@cafevariome.org
   license:
     name: Apache 2.0
     url: http://www.apache.org/licenses/LICENSE-2.0.html
   version: v1.0
 servers:
-- url: /
+- url: https://rdnexusdev.molgeniscloud.org/cv2/BeaconAPI/
+  description: Development server
 paths:
+  /info:
+    get:
+      summary: "Get information regarding this beacon."
+      responses:
+        200:
+          $ref: '#/components/schemas/InfoResponse'
+  /filtering_terms:
+    get:
+      summary: "Get the valid filtering terms to be used in querying/handled by this beacon."
+      responses:
+        200:
+          $ref: '#/components/schemas/FilterTermsResponse'
+  /map:
+    get:
+      summary: "Get the list of endpoints included in this beacon i.e., individuals."
+      responses:
+        200:
+          $ref: '#/components/schemas/MapResponse'
+  /service-info:
+    get:
+      summary: "Get information about the beacon using GA4GH ServiceInfo format."
+      responses:
+        200:
+          $ref: '#/components/schemas/ServiceInfoResponse'
+  /configuration:
+    get:
+      summary: "Get the configuration of this beacon."
+      responses:
+        200:
+          $ref: '#/components/schemas/ConfigurationResponse'
+  /entry_types:
+    get:
+      summary: "Get the list of beacon entry types."
+      responses:
+        200:
+          $ref: '#/components/schemas/EntryTypesResponse'
   /individuals:
     post:
       summary: "Request to retrive count of individuals from a data source (i.e. patients)"
@@ -19,7 +58,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/IndividualRequest'
-        required: false
+        required: true
       responses:
         200:
           $ref: '#/components/schemas/IndividualResponse'
@@ -30,25 +69,27 @@ paths:
           description: "The data source does not allow this API call"
           content: {}
       security:
-      - bearerAuth: []
-      x-codegen-request-body-name: body
+      - apiAuth: []
 components:
   schemas:
     IndividualRequest:
       required:
+      - meta
       - query
       type: object
       properties:
-        description:
-          type: string
-        properties:
-          $ref: '#/components/schemas/RequestProperties'
-      description: "Request to return individuals count for given CDEs input parameters"
-    RequestProperties:
-      type: object
-      properties:
+        meta: 
+          $ref: '#/components/schemas/MetaContent'
         query:
           $ref: '#/components/schemas/RequestQuery'
+      description: "Request to return individuals count for given CDEs input parameters"
+    # RequestProperties:
+    #   type: object
+    #   properties:
+    #     meta: 
+    #       $ref: '#/components/schemas/MetaContent'
+    #     query:
+    #       $ref: '#/components/schemas/RequestQuery'
     RequestQuery:
       type: object
       properties:
@@ -58,32 +99,177 @@ components:
           $ref: '#/components/schemas/RequestFilter'
       description: "Input of the query"
     RequestFilter:
+      required:
+      - type
+      - id
+      - operator
       type: array
       items:
         type: object
         properties:
           type:
             type: string
-            description: "Concept ID of CDEs. e.g sex(obo:NCIT_C28421)"
+            # enum: [obo:NCIT_C28421, sio:SIO_001003, sio:SIO_010056, obo:NCIT_C16612, obo:NCIT_C25150,  efo:EFO_0004847, obo:NCIT_C156420]
+            description: >
+                  Concept ID of CDEs. 
+                    Allowed terms:
+                     * `obo:NCIT_C28421` - Sex
+                     * `sio:SIO_001003` - Diagnosis of the rare disease
+                     * `sio:SIO_010056` - Phenotype
+                     * `obo:NCIT_C16612` - Causative Gene(s)
+                     * `obo:NCIT_C25150` - Age this year
+                     * `efo:EFO_0004847` - Age at disease manifestation
+                     * `obo:NCIT_C156420` - Age at diagnosis
+            # description: "Concept ID of CDEs. e.g sex(obo:NCIT_C28421)"
             example: "obo:NCIT_C28421"
           id:
             type: string
-            description: "The actual values of the CDE. e.g in case of sex(obo:NCIT_C28421) one of the CDE sex terms Female(obo:NCIT_C16576)"
+            description: >
+              The actual values of the CDE. Allowed values:
+                * For `obo:NCIT_C28421`(Sex): 
+                  * `obo:NCIT_C16576`, (Female)
+                  * `obo:NCIT_C20197`, (Male)
+                  * `obo:NCIT_C124294`, (Undetermined)
+                  * `obo:NCIT_C17998` (Unknown)
+                * For `sio:SIO_001003`(Diagnosis) - Any ORPHA term
+                * For `sio:SIO_010056`(Phenotype) - Any HPO term
+                * For `obo:NCIT_C16612`(Causative Gene) - Any HGNC Gene symbol
+                * For `obo:NCIT_C25150`(Age this year) - Any integer
+                * For `efo:EFO_0004847`(Age at disease manifestation) - Any integer
+                * For `obo:NCIT_C156420`(Age at diagnosis) - Any integer
+            # enum: [obo:NCIT_C16576,obo:NCIT_C20197,obo:NCIT_C124294,obo:NCIT_C17998, An Orphanet Term, A HPO Term, An integer for age ranges]
             example: "obo:NCIT_C16576"
           operator:
             type: string
             description: "This is a advance filter option to include comparison operators in the query."
             example: "="
         description: "Query parameters to filter individuals based on CDEs."
-    IndividualResponse:
+    InfoResponse:
       required:
+      - meta
       - response
       type: object
       properties:
+        meta:
+          $ref: '#/components/schemas/MetaContent'
         response:
-          $ref: '#/components/schemas/IndividualResponseContent'
+          $ref: '#/components/schemas/InfoResponseContent'
+      description: |
+        Respond with information regarding this Beacon.
+    FilterTermsResponse:
+      description: |
+        List of filtering terms for querying this Beacon.
+    ServiceInfoResponse:
+      description: |
+        Respond with the Service Info of this Beacon.
+    MapResponse:
+      description: |
+        Respond with the list of available query endpoints in this Beacon.
+    EntryTypesResponse:
+      description: |
+        Respond with the entry types available  in this Beacon Implementation.
+    ConfigurationResponse:
+      description: |
+        Respond with this Beacon's configuration information.
+    MetaContent:
+      description: |
+        Information about the response that could be relevant for the Beacon client in order to interpret the results.
+      required: 
+      - apiVersion
+      - beaconId
+      - returnedSchemas
+      type: object
+      properties: 
+        apiVersion:
+          type: string
+          description: |
+            Version of the API.
+          example: v2.0
+        beaconId:
+          type: string
+          description: |
+            Identifier of the beacon, as defined in Beacon, in reverse domain name notation.
+          example: BeaconAPI.cv2.rdnexusdev.molgeniscloud.org
+        returnedSchemas:
+          type: object
+          description: |
+            Set of schemas to be used in the response to a request.
+          properties:
+            entityType:
+              type: string
+            schema:
+              type: string
+    InfoResponseContent:
+      description: |
+        Metadata describing a Beacon instance.
+      required:
+      - apiVersion
+      - environment
+      - id
+      - name
+      - organisation
+      properties:
+        apiVersion:
+          type: string
+          description: |
+            Version of the API provided by the Beacon. 
+          example: v2.0
+        environment:
+          type: string
+          description: |
+            Environment the service is running in. Use this to distinguish between production, development and testing/staging deployments. Allowed: prod, test, dev, staging
+          example: dev
+        id:
+          type: string
+          description: |
+            Unique identifier of the Beacon. Use reverse domain name notation.
+        name:
+          type: string
+          description: |
+            Name of the Beacon. 
+        organisation:
+          type: object
+          description: |
+            Organization owning the Beacon.
+          required:
+          - id
+          - name
+          properties: 
+            id:
+              type: string
+              description: |
+                Unique identifier of the organization.
+            name:
+              type: string
+              description: |
+                Name of the organization.
+    IndividualResponse:
       description: |
         Response of a query over individuals counts.
+      required:
+      - meta
+      - responseSummary
+      type: object
+      properties:
+        meta:
+          $ref: '#/components/schemas/MetaContent'
+        responseSummary:
+          $ref: '#/components/schemas/IndividualResponseContent'
+        info:
+          description: | 
+            Beacon only responds with this info object if there are any unsupported filters in the query.
+          $ref: '#/components/schemas/WarningResponse'
+    WarningResponse:
+      description: |
+        Any unsupported filters go here.
+      required: 
+      - warnings
+      properties:
+        warnings:
+          type: object
+          description: |
+            Respond with a list of unsupported filter(s).
+          example: obo:NCIT_C16612
     IndividualResponseContent:
       required:
       - exists
@@ -100,7 +286,7 @@ components:
       description: |
         Response of the query indicating if the query yield any results. If the query is successful then the count will be returned as a response.
   securitySchemes:
-    bearerAuth:
-      type: http
-      scheme: bearer
-      bearerFormat: JWT
+    apiAuth:
+      type: apiKey
+      in: header
+      name: X-API-KEY

--- a/individuals_api.yml
+++ b/individuals_api.yml
@@ -93,8 +93,6 @@ components:
     RequestQuery:
       type: object
       properties:
-        description:
-          type: string
         filters:
           $ref: '#/components/schemas/RequestFilter'
       description: "Input of the query"
@@ -137,7 +135,7 @@ components:
                 * For `obo:NCIT_C25150`(Age this year) - Any integer
                 * For `efo:EFO_0004847`(Age at disease manifestation) - Any integer
                 * For `obo:NCIT_C156420`(Age at diagnosis) - Any integer
-            # enum: [obo:NCIT_C16576,obo:NCIT_C20197,obo:NCIT_C124294,obo:NCIT_C17998, An Orphanet Term, A HPO Term, An integer for age ranges]
+            enum: [obo:NCIT_C16576,obo:NCIT_C20197,obo:NCIT_C124294,obo:NCIT_C17998, An Orphanet Term, A HPO Term, An integer for age ranges]
             example: "obo:NCIT_C16576"
           operator:
             type: string
@@ -289,4 +287,4 @@ components:
     apiAuth:
       type: apiKey
       in: header
-      name: X-API-KEY
+      name: auth-key

--- a/individuals_api_v0.2.yml
+++ b/individuals_api_v0.2.yml
@@ -123,13 +123,13 @@ components:
           description: >
                   Concept ID of CDEs. 
                     Allowed terms:
-                     * `NCIT_C28421` - Sex
-                     * `data_2295` - Causative Gene(s)
-                     * `NCIT_C83164` - Age this year
-                     * `NCIT_C124353` - Symptom Onset
-                     * `NCIT_C156420` - Age at diagnosis
+                     * `obo:NCIT_C28421` - Sex
+                     * `edam:data_2295` - Causative Gene(s)
+                     * `obo:NCIT_C83164` - Age this year
+                     * `obo:NCIT_C124353` - Symptom Onset
+                     * `obo:NCIT_C156420` - Age at diagnosis
                      * `Available Materials` - Available Materials
-          example: "NCIT_C28421"
+          example: "obo:NCIT_C28421"
         operator:
           type: string
           description: "This is a advance filter option to include comparison operators in the query."
@@ -138,16 +138,16 @@ components:
           type: string
           description: >
               The actual values of the CDE. Allowed values:
-                * For `NCIT_C28421`(Sex): 
-                  * `NCIT_C16576`, (Female)
-                  * `NCIT_C20197`, (Male)
-                  * `NCIT_C124294`, (Undetermined)
-                  * `NCIT_C17998` (Unknown)
-                * For `data_2295`(Causative Gene) - Any HGNC Gene symbol
-                * For `NCIT_C83164`(Age this year) - Any birth year as an integer
-                * For `NCIT_C124353`(Symptom Onset) - Any integer
-                * For `NCIT_C156420`(Age at diagnosis) - Any integer
-          example: "NCIT_C16576"
+                * For `obo:NCIT_C28421`(Sex): 
+                  * `obo:NCIT_C16576`, (Female)
+                  * `obo:NCIT_C20197`, (Male)
+                  * `obo:NCIT_C124294`, (Undetermined)
+                  * `obo:NCIT_C17998` (Unknown)
+                * For `edam:data_2295`(Causative Gene) - Any HGNC Gene symbol
+                * For `obo:NCIT_C83164`(Age this year) - Any birth year as an integer
+                * For `obo:NCIT_C124353`(Symptom Onset) - Any integer
+                * For `obo:NCIT_C156420`(Age at diagnosis) - Any integer
+          example: "obo:NCIT_C16576"
       description: "Query parameters to filter individuals based on CDEs."
     OntologyRequestArrayFilter:
       required:
@@ -158,12 +158,12 @@ components:
           anyOf:
           - type: string
           - type: array
-          example: "Orphanet_558 or [Orphanet_558,Orphanet_773,Orphanet_12345]"
+          example: "ordo:Orphanet_558 or [ordo:Orphanet_558,ordo:Orphanet_773,ordo:Orphanet_12345]"
           description: >
                     Concept ID of CDEs. 
                       Allowed values:
-                      * For Disease or Disorder: A single value or an array of orphanet terms. e.g. Orphanet_558 or [Orphanet_558, Orphanet_773]
-                      * For Phenotype: A single value or an array of HPO terms. e.g. HP_0001251 or [HP_0001251, HP_0012250]
+                      * For Disease or Disorder: A single value or an array of orphanet terms. e.g. ordo:Orphanet_558 or [ordo:Orphanet_558, ordo:Orphanet_773]
+                      * For Phenotype: A single value or an array of HPO terms. e.g. obo:HP_0001251 or [obo:HP_0001251, obo:HP_0012250]
     InfoResponse:
       required:
       - meta
@@ -437,7 +437,7 @@ components:
                     id: 
                       description: |
                         A CURIE identifier as `id` for ontology term.
-                      example: NCIT:C25190
+                      example: obo:NCIT:C25190
                       type: string
                 partOfSpecification:
                   description: |
@@ -472,7 +472,7 @@ components:
           type: object
           description: |
             Respond with a list of unsupported filter(s).
-          example: NCIT_C16612
+          example: obo:NCIT_C16612
     IndividualResponseContent:
       required:
       - exists

--- a/individuals_api_v0.2.yml
+++ b/individuals_api_v0.2.yml
@@ -143,11 +143,22 @@ components:
                   * `obo:NCIT_C20197`, (Male)
                   * `obo:NCIT_C124294`, (Undetermined)
                   * `obo:NCIT_C17998` (Unknown)
-                * For `edam:data_2295`(Causative Gene) - Any HGNC Gene symbol
+                  * An array of any of the above. Ex: ["obo:NCIT_C16576","obo:NCIT_C20197","obo:NCIT_C17998"].
+                * For `edam:data_2295`(Causative Gene) - Any HGNC Gene symbol or an array of HGNC Symbols.
                 * For `obo:NCIT_C83164`(Age this year) - Any birth year as an integer
                 * For `obo:NCIT_C124353`(Symptom Onset) - Any integer
                 * For `obo:NCIT_C156420`(Age at diagnosis) - Any integer
-          example: "obo:NCIT_C16576"
+                * For `Available Materials`: 
+                  * Whole Genome Sequence
+                  * Exome panel sequence
+                  * RNA sequence
+                  * Methylomics
+                  * Epigenomics
+                  * Pedigree data
+                  * Clinical data
+                  * Biosamples
+                  * An array of any of the above
+          example: "obo:NCIT_C16576 or [obo:NCIT_C16576,obo:NCIT_C20197]"
       description: "Query parameters to filter individuals based on CDEs."
     OntologyRequestArrayFilter:
       required:

--- a/individuals_api_v0.2.yml
+++ b/individuals_api_v0.2.yml
@@ -1,0 +1,495 @@
+openapi: 3.0.1
+info:
+  title: Virtual platform Beacon API
+  x-beaconVersion: v2.0
+  description: EJPRD virtual platform data record APIs
+  contact:
+    email: admin@cafevariome.org
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+  version: v0.2
+servers:
+- url: https://rdnexusdev.molgeniscloud.org/cv2/BeaconAPI/
+  description: Development server
+paths:
+  /info:
+    get:
+      summary: "Get information regarding this beacon."
+      tags:
+      - Informational Endpoints
+      responses:
+        200:
+          $ref: '#/components/schemas/InfoResponse'
+  /filtering_terms:
+    get:
+      summary: "Get the valid filtering terms to be used in querying/handled by this beacon."
+      tags:
+      - Informational Endpoints
+      responses:
+        200:
+          $ref: '#/components/schemas/FilteringTermsResponse'
+  /map:
+    get:
+      summary: "Get the list of endpoints included in this beacon i.e., individuals."
+      tags:
+      - Informational Endpoints
+      responses:
+        200:
+          $ref: '#/components/schemas/MapResponse'
+  /service-info:
+    get:
+      summary: "Get information about the beacon using GA4GH ServiceInfo format."
+      tags:
+      - Informational Endpoints
+      responses:
+        200:
+          $ref: '#/components/schemas/ServiceInfoResponse'
+  /configuration:
+    get:
+      summary: "Get the configuration of this beacon."
+      tags:
+      - Informational Endpoints
+      responses:
+        200:
+          $ref: '#/components/schemas/ConfigurationResponse'
+  /entry_types:
+    get:
+      summary: "Get the list of beacon entry types."
+      tags:
+      - Informational Endpoints
+      responses:
+        200:
+          $ref: '#/components/schemas/EntryTypesResponse'
+  /individuals:
+    post:
+      summary: "Request to retrive count of individuals from a data source (i.e. patients)"
+      tags:
+      - Query Endpoints
+      operationId: individuals_request
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/IndividualRequest'
+        required: true
+      responses:
+        200:
+          $ref: '#/components/schemas/IndividualResponse'
+        400:
+          description: "Input data malformed"
+          content: {}
+        403:
+          description: "The data source does not allow this API call"
+          content: {}
+      security:
+      - apiAuth: []
+components:
+  schemas:
+    IndividualRequest:
+      required:
+      - meta
+      - query
+      type: object
+      properties:
+        meta: 
+          $ref: '#/components/schemas/MetaContent'
+        query:
+          $ref: '#/components/schemas/RequestQuery'
+      description: "Request to return individuals count for given CDEs input parameters"
+    RequestQuery:
+      type: object
+      properties:
+        filters:
+          $ref: '#/components/schemas/RequestFilter'
+      description: "Input of the query"
+    RequestFilter:
+      required:
+      - id
+      type: array
+      items:
+        anyOf:
+        - $ref: '#/components/schemas/AlphanumericRequestFilter'
+        - $ref: '#/components/schemas/OntologyRequestArrayFilter'
+    AlphanumericRequestFilter:
+      required:
+      - id
+      - operator
+      - value
+      type: object
+      properties:
+        id:
+          type: string
+          description: >
+                  Concept ID of CDEs. 
+                    Allowed terms:
+                     * `NCIT_C28421` - Sex
+                     * `data_2295` - Causative Gene(s)
+                     * `NCIT_C83164` - Age this year
+                     * `NCIT_C124353` - Symptom Onset
+                     * `NCIT_C156420` - Age at diagnosis
+                     * `Available Materials` - Available Materials
+          example: "NCIT_C28421"
+        operator:
+          type: string
+          description: "This is a advance filter option to include comparison operators in the query."
+          example: "="
+        value:
+          type: string
+          description: >
+              The actual values of the CDE. Allowed values:
+                * For `NCIT_C28421`(Sex): 
+                  * `NCIT_C16576`, (Female)
+                  * `NCIT_C20197`, (Male)
+                  * `NCIT_C124294`, (Undetermined)
+                  * `NCIT_C17998` (Unknown)
+                * For `data_2295`(Causative Gene) - Any HGNC Gene symbol
+                * For `NCIT_C83164`(Age this year) - Any birth year as an integer
+                * For `NCIT_C124353`(Symptom Onset) - Any integer
+                * For `NCIT_C156420`(Age at diagnosis) - Any integer
+          example: "NCIT_C16576"
+      description: "Query parameters to filter individuals based on CDEs."
+    OntologyRequestArrayFilter:
+      required:
+      - id
+      type: object
+      properties:
+        id:
+          anyOf:
+          - type: string
+          - type: array
+          example: "Orphanet_558 or [Orphanet_558,Orphanet_773,Orphanet_12345]"
+          description: >
+                    Concept ID of CDEs. 
+                      Allowed values:
+                      * For Disease or Disorder: A single value or an array of orphanet terms. e.g. Orphanet_558 or [Orphanet_558, Orphanet_773]
+                      * For Phenotype: A single value or an array of HPO terms. e.g. HP_0001251 or [HP_0001251, HP_0012250]
+    InfoResponse:
+      required:
+      - meta
+      - response
+      type: object
+      properties:
+        meta:
+          $ref: '#/components/schemas/MetaContent'
+        response:
+          $ref: '#/components/schemas/InfoResponseContent'
+      description: |
+        Respond with information regarding this Beacon.
+    FilteringTermsResponse:
+      required:
+      - meta
+      - response
+      properties:
+        meta:
+          $ref: '#/components/schemas/MetaContent'
+        response:
+          $ref: '#/components/schemas/FilterTermsResponseContent'
+    FilterTermsResponseContent:
+      required:
+      - filteringTerms
+      properties:
+        filteringTerms:
+          $ref: '#/components/schemas/FilterTermsResponse'
+    FilterTermsResponse:
+      description: |
+        List of filtering terms for querying this Beacon.
+      required: 
+      - id
+      - type
+      type: object
+      properties:
+        id:
+          type: string
+          description: |
+            The field id in the case of numeric or alphanumeric fields, or the term id in the case of ontology or custom terms. CURIE syntax in the case of an ontology term.
+          example: NCIT_C28421
+        type: 
+          type: string
+          description: |
+            Either "custom", "alphanumeric" or ontology/terminology full name.
+          example: alphanumeric or ontology or custom
+        label:
+          type: string
+          description: |
+            This would be the "preferred Label" in the case of an ontology term.
+          example: Symptom Onset
+    ServiceInfoResponse:
+      description: |
+        Respond with the Service Info of this Beacon.
+    MapResponse:
+      description: |
+        Respond with the list of available query endpoints in this Beacon.
+    EntryTypesResponse:
+      required:
+      - meta
+      - response
+      type: object
+      properties: 
+        meta:
+          $ref: '#/components/schemas/MetaContent'
+        response:
+          $ref: '#/components/schemas/ETResponseContent'
+      description: |
+        Respond with the entry types available  in this Beacon Implementation.
+    ConfigurationResponse:
+      description: |
+        Respond with this Beacon's configuration information.
+    MetaContent:
+      description: |
+        Information about the response that could be relevant for the Beacon client in order to interpret the results.
+      required: 
+      - apiVersion
+      - beaconId
+      - receivedRequestSummary
+      - returnedSchemas
+      type: object
+      properties: 
+        apiVersion:
+          type: string
+          description: |
+            Version of the API.
+          example: v2.0
+        beaconId:
+          type: string
+          description: |
+            Identifier of the beacon, as defined in Beacon, in reverse domain name notation.
+          example: BeaconAPI.cv2.rdnexusdev.molgeniscloud.org
+        returnedSchemas:
+          type: object
+          description: |
+            Set of schemas to be used in the response to a request.
+          properties:
+            entityType:
+              type: string
+            schema:
+              type: string
+    IndividualsMetaResponseContent:
+      description: |
+        Information about the response that could be relevant for the Beacon client in order to interpret the results.
+      required: 
+      - apiVersion
+      - beaconId
+      - receivedRequestSummary
+      - returnedGranularity
+      - returnedSchemas
+      type: object
+      properties: 
+        apiVersion:
+          type: string
+          description: |
+            Version of the API.
+          example: v2.0
+        beaconId:
+          type: string
+          description: |
+            Identifier of the beacon, as defined in Beacon, in reverse domain name notation.
+          example: BeaconAPI.cv2.rdnexusdev.molgeniscloud.org
+        receivedRequestSummary:
+          required:
+          - apiVersion
+          - requestedGranularity
+          - requestedSchemas
+          type: object
+          description: |
+            Section of the response that summarize the request with the following fields received as its been interpreted by the Beacon server. This could also just return the complete Beacon request made by the user.
+          properties: 
+            apiVersion:
+              type: string
+            filters:
+              type: object
+              description: |
+                Filters as submitted in the request.
+              $ref: '#/components/schemas/RequestFilter'
+            requestedGranularity: 
+              type: string
+              example: boolean, count, aggregated, record
+              default: count
+            requestedSchemas:
+              type: object
+              description: |
+                Set of schemas to be used in the response to a request.
+              properties:
+                entityType:
+                  type: string
+                schema:
+                  type: string
+        returnedGranularity: 
+              type: string
+              example: boolean, count, aggregated, record
+              default: count
+        returnedSchemas:
+          type: object
+          description: |
+            Set of schemas to be used in the response to a request.
+          properties:
+            entityType:
+              type: string
+            schema:
+              type: string
+    InfoResponseContent:
+      description: |
+        Metadata describing a Beacon instance.
+      required:
+      - apiVersion
+      - environment
+      - id
+      - name
+      - organisation
+      properties:
+        apiVersion:
+          type: string
+          description: |
+            Version of the API provided by the Beacon. 
+          example: v2.0
+        environment:
+          type: string
+          description: |
+            Environment the service is running in. Use this to distinguish between production, development and testing/staging deployments. Allowed: prod, test, dev, staging
+          example: dev
+        id:
+          type: string
+          description: |
+            Unique identifier of the Beacon. Use reverse domain name notation.
+        name:
+          type: string
+          description: |
+            Name of the Beacon. 
+        organisation:
+          type: object
+          description: |
+            Organization owning the Beacon.
+          required:
+          - id
+          - name
+          properties: 
+            id:
+              type: string
+              description: |
+                Unique identifier of the organization.
+            name:
+              type: string
+              description: |
+                Name of the organization.
+    ETResponseContent:
+      required: 
+      - entryTypes
+      type: object
+      properties:
+        entryTypes:
+          required:
+          - Individuals
+          type: object
+          description: |
+            List of entry types. 
+          properties:
+            Individuals:
+              description: |
+                Definition of an element or entry type including the Beacon v2 required and suggested attributes. This schema purpose is to describe each type of entities included in this beacon, hence Beacon clients could have some metadata about such entities.
+              required: 
+              - defaultSchema
+              - id
+              - name
+              - ontologyTermForThisType
+              - partOfSpecification
+              type: object
+              properties: 
+                defaultSchema:
+                  description: |
+                    Definition of an annotated URL address or a file reference.
+                  required:
+                    - id
+                    - name
+                    - referenceToSchemaDefinition
+                  properties:
+                    id:
+                      type: string
+                      description: |
+                        A (unique) identifier of the element.
+                      example: Individuals
+                    name:
+                      type: string
+                      description: |
+                        A distinctive name for the element.
+                      example: Individuals
+                    referenceToSchemaDefinition:
+                      type: string
+                      description: |
+                        Conforming Schema of the element.
+                      example: https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2-Models/main/BEACON-V2-draft4-Model/individuals/defaultSchema.json
+                id:
+                  description: |
+                    A unique identifier of the element.
+                  type: string
+                  example: Individuals
+                name: 
+                  description: |
+                    A distinctive name for the element.
+                  type: string
+                  example: Individuals
+                ontologyTermForThisType: 
+                  description: |
+                    Definition of an ontology term.
+                  type: object
+                  required:
+                  - id
+                  properties: 
+                    id: 
+                      description: |
+                        A CURIE identifier as `id` for ontology term.
+                      example: NCIT:C25190
+                      type: string
+                partOfSpecification:
+                  description: |
+                    This label is to group together entry types that are part of the same specification.
+                  type: string
+                  example: Beacon v2.0
+      description: |
+        Respond with a list of entry types conforming to Beacon v2 spec.
+    IndividualResponse:
+      description: |
+        Response of a query over individuals counts.
+      required:
+      - meta
+      - responseSummary
+      type: object
+      properties:
+        meta:
+          $ref: '#/components/schemas/IndividualsMetaResponseContent'
+        responseSummary:
+          $ref: '#/components/schemas/IndividualResponseContent'
+        info:
+          description: | 
+            Beacon only responds with this info object if there are any unsupported filters in the query.
+          $ref: '#/components/schemas/WarningResponse'
+    WarningResponse:
+      description: |
+        Any unsupported filters go here.
+      required: 
+      - warnings
+      properties:
+        warnings:
+          type: object
+          description: |
+            Respond with a list of unsupported filter(s).
+          example: NCIT_C16612
+    IndividualResponseContent:
+      required:
+      - exists
+      - numTotalResults
+      type: object
+      properties:
+        exists:
+          type: boolean
+          description: |
+            Indicator of whether any individual was observed in the
+            data source for the given query with CDEs parameter. This should be non-null, unless there was an error, in which case `error` has to be non-null.
+        numTotalResults:
+          type: integer
+      description: |
+        Response of the query indicating if the query yield any results. If the query is successful then the count will be returned as a response.
+  securitySchemes:
+    apiAuth:
+      type: apiKey
+      in: header
+      name: auth-key


### PR DESCRIPTION
### Overview
This pull request suggests changes to Beaconise the specification. Changes include: 
- Adding informational endpoints.
- Defining schemas for responses.
- Updated documentation to reflect changes. 

### Further Discussion
1. Define the ontologies used in an implementation - should the complete Ontology URI be used? 
2. Filter alignment with Beacon v2 spec - to be compliant with Beacon, align the current custom filters to be more standardised by making CDE terms as concepts instead of filter types (see below).
3. AnyOf option for disease/ontology terms - the need for the ability to send multiple terms, rather than multiple queries using either:
      - an array of 'id' elements as an **OR** query, or, 
      - create a custom filter using an array.

![image](https://user-images.githubusercontent.com/24955128/204246452-57a31f23-1d69-4bcd-8527-9bd9458fb838.png)
