### PR TITLE
Feat/catalogs metadata schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,7 +467,7 @@ The filter **SHOULD** be one of the terms from the [filters and permitted values
 
 > Method: POST
 
-[/catalogs](https://app.swaggerhub.com/apis/VM172_1/vp_individuals/v0.2#/Query%20Endpoints/catalogs_request) endpoint returns the **__metadata of RD resource__**. Filters are provided as a part of the body while using a POST request to query resources.
+[/catalogs](https://app.swaggerhub.com/apis/VM172_1/vp_individuals/v0.2#/Query%20Endpoints/catalogs_request) endpoint returns the **__metadata of RD resources__**, using as response, a model compatible with the [Resource Metadata Schema](https://github.com/ejp-rd-vp/resource-metadata-schema). Filters are provided as a part of the body while using a POST request to query resources. Available filters correspond also to dcat properties from the Resource Metadata Schema
 
 <h4 id="catalogs-filters"> List of filters and permitted values for the catalogs endpoint </h4>
 
@@ -475,8 +475,8 @@ The filter **SHOULD** be one of the terms from the [filters and permitted values
 
 <table>
 <thead>
-        <th>CDE Concept</th>
-        <th>CDE Term</th>
+        <th>Metadata Schema Concept</th>
+        <th>Metadata Schema Term</th>
         <th>Beacon Filter Type</th>
         <th>ID</th>
         <th>Operator</th>
@@ -485,20 +485,37 @@ The filter **SHOULD** be one of the terms from the [filters and permitted values
 <tbody>
     <tr>
         <td><b>Disease or Disorder</b></td>
-        <td>obo:NCIT_C2991</td>
+        <td>dcat:theme</td>
         <td>Ontology</td>
-        <td>A single value or an array of orphanet terms. <b>e.g. Orphanet_558 or [Orphanet_558, Orphanet_773]</b></td>
+        <td>A single value or an array of orphanet terms in CURIE syntax prefixed with `ordo:`<b>e.g. ordo:Orphanet_558 or [ordo:Orphanet_558, ordo:Orphanet_773]</b></td>
         <td colspan="2">NA</td>
     </tr>
     <tr>
         <td><b>Phenotype</b></td>
         <td>sio:SIO_010056</td>
         <td>Ontology</td>
-        <td>A single value or an array of HPO terms. <b>e.g. HP_0001251 or [HP_0001251, HP_0012250]</b></td>
+        <td>A single value or an array of HPO terms prefixed with `HP:` <b>e.g. HP:0001251 or [HP:0001251, HP:0012250]</b></td>
         <td colspan="2">NA</td>
     </tr>
     <tr>
-        <td><b>ID </b></td> 
+        <td rowspan="4"><b>Resource Types</b></td>
+        <td rowspan="4">rdf:type</td>
+        <td rowspan="4">Alphanumerical</td>
+        <td rowspan="4">A single value or ana array of values representing a resource type of the resource. It must be one of the types defined in EJP Resource Metadata Schema</td>
+        <td rowspan="4">=</td>
+        <td>ejp:PatientRegistry</td>
+    </tr>
+    <tr>
+        <td>ejp:Biobank</td>
+    </tr>
+    <tr>
+        <td>ejp:Guideline</td>
+    </tr>
+    <tr>
+        <td>dcat:Dataset</td>
+    </tr>
+    <tr>
+        <td><b>ID</b></td> 
         <td>NA</td>
         <td>Alphanumerical</td>
         <td>id</td>
@@ -507,45 +524,28 @@ The filter **SHOULD** be one of the terms from the [filters and permitted values
     </tr>
     <tr>
         <td><b>Name </b></td>
-        <td>NA</td>
+        <td>dct:title</td>
         <td>Alphanumerical</td>
-        <td>name</td>
+        <td>The name of the resource</td>
         <td>=</td>
         <td>any String</td>
     </tr>
     <tr>
         <td><b>Description </b> </td>
-        <td>NA</td>
+        <td>dct:description</td>
         <td>Alphanumerical</td>
-        <td>description</td>
+        <td>The description of the resource</td>
         <td>=</td>
         <td>any String</td>
     </tr>
-    <tr>
+    <!-- <tr>
         <td><b>Organisation </b> </td>
         <td>NA</td>
         <td>Alphanumerical</td>
         <td>organisation</td>
         <td>=</td>
         <td>any String</td>
-    </tr>
-    <tr>
-        <td rowspan="4"><b>Resource Types</b></td>
-        <td rowspan="4">NA</td>
-        <td rowspan="4">Alphanumerical</td>
-        <td rowspan="4">resourceTypes</td>
-        <td rowspan="4">=</td>
-        <td>PatientRegistryDataset</td>
-    </tr>
-    <tr>
-        <td>BiobankDataset</td>
-    </tr>
-    <tr>
-        <td>KnowledgeBase</td>
-    </tr>
-    <tr>
-        <td>An array of any of the above</td>
-    </tr>
+    </tr> -->
 </tbody>
 </table>
 
@@ -555,25 +555,28 @@ The filter **SHOULD** be one of the terms from the [filters and permitted values
 
 <h3 id="catalogs-filters-description"> Catalogs Filters Description </h3>
 
-**Disease or Disorder**: All rare diseases that are associated **within a catalog**,
+**Disease or Disorder**: All rare diseases that are associated **within a catalog**. It corresponds to the `dcat:theme` property of the Resource Metadata Schema. The values follow CURIE syntax and use the `ordo:` prefix.
 
-**Phenotype**: HPO terms of all phenotypes observed **within a catalog** of rare disease resources.
+**Phenotype**: HPO terms of all phenotypes observed **within a catalog** of rare disease resources. The values follow CURIE syntax and use the `HP:` prefix. 
 
-**Available Materials**: A list of material information that is available **within the catalog**.
+**ID**: The resource identifier ID **within the catalog**. It corresponds to the identifier of the RDF resource
 
-**ID**: The resource identifier ID **within the catalog**.
+**Name**: The name of the resource in the **catalog**. It corresponds to the `dct:title` of the Resource Metadata Schema
 
-**Name**: The name of the resource in the **catalog**. 
-
-**Description**: The description of the resource in the **catalog**. 
+**Description**: The description of the resource in the **catalog**. It corresponds to the `dct:description` property of the Resource Metadata Schema
 
 **Organisation**: The organisation of the resource in the **catalog**. 
 
-**Resource Types**: Types of resources **within the catalog**. Permitted values for this filter are: PatientRegistryDataset, BiobankDataset, KnowledgeBase or an array of any of these values.
+**Resource Types**: Types of resources **within the catalog**. Permitted values for this filter are the type of resources in the Resource Metadata Schema:  `ejp:PatientRegistry`, `ejp:Biobank`, `ejp:Guideline`, `dcat:Datasest` or an array of any of these values.
 
 [ ^ Back to the top](#top)
 
 <hr>
+
+<h3 id="catalogs-response">Catalogs Response</h3>
+
+The response is a Beacon Collection response that correspond to a Resource described by the Resource Meatadata Schema.
+ 
 
 <h3> An example request & response to query for resources via the /catalogs endpoint is shown below: </h3>
 

--- a/README.md
+++ b/README.md
@@ -503,13 +503,13 @@ The filter **SHOULD** be one of the terms from the [filters and permitted values
         <td rowspan="4">Alphanumerical</td>
         <td rowspan="4">A single value or ana array of values representing a resource type of the resource. It must be one of the types defined in EJP Resource Metadata Schema</td>
         <td rowspan="4">=</td>
-        <td>ejp:PatientRegistry</td>
+        <td>ejprd:PatientRegistry</td>
     </tr>
     <tr>
-        <td>ejp:Biobank</td>
+        <td>ejprd:Biobank</td>
     </tr>
     <tr>
-        <td>ejp:Guideline</td>
+        <td>ejprd:Guideline</td>
     </tr>
     <tr>
         <td>dcat:Dataset</td>
@@ -567,7 +567,7 @@ The filter **SHOULD** be one of the terms from the [filters and permitted values
 
 **Organisation**: The organisation of the resource in the **catalog**. 
 
-**Resource Types**: Types of resources **within the catalog**. Permitted values for this filter are the type of resources in the Resource Metadata Schema:  `ejp:PatientRegistry`, `ejp:Biobank`, `ejp:Guideline`, `dcat:Datasest` or an array of any of these values.
+**Resource Types**: Types of resources **within the catalog**. Permitted values for this filter are the type of resources in the Resource Metadata Schema:  `ejprd:PatientRegistry`, `ejprd:Biobank`, `ejprd:Guideline`, `dcat:Datasest` or an array of any of these values.
 
 [ ^ Back to the top](#top)
 
@@ -575,10 +575,22 @@ The filter **SHOULD** be one of the terms from the [filters and permitted values
 
 <h3 id="catalogs-response">Catalogs Response</h3>
 
-The response is a Beacon Collection response that correspond to a Resource described by the Resource Meatadata Schema.
- 
+The response is a Beacon Collection response that correspond to a Resource described by the Resource Metadata Schema. Depending on the resource type, the properties may slighlty differ: for example some resource types can have properties that others don't have. Notice that an important field in all resources is the `@context` that specifies the semantics of the properties returned. It must be the [link](https://raw.githubusercontent.com/ejp-rd-vp/vp-api-specs/main/versions/json-ld-contexts/ejprd-context.json) to the `json-ld-contexts/ejprd-context.json` file  in this repository. The schemas for each specific resource are in teh `/schemas` directory.
+In the meta section of the response, the `returnedSchemas` object must specify the correct json schema for the resource. An example is:
 
-<h3> An example request & response to query for resources via the /catalogs endpoint is shown below: </h3>
+```JSON
+"returnedSchemas": [
+    {
+        "entityType": "resources",
+        "schema": "ejprd-biobank-registry-v1.0.0",
+        "name": "EJPRD schema for biobank and patient registry",
+        "url": "https://raw.githubusercontent.com/ejp-rd-vp/vp-api-specs/schemas/biobank-registry-schema.json",
+        "version": "v1.0.0"
+    }
+]
+```
+
+<h3> An example request & response to query for resources via the /catalogs endpoint is shown below. </h3>
 
 <h5 id="catalogs-example"> EXAMPLE /catalogs REQUEST </h5>
 
@@ -590,56 +602,97 @@ The response is a Beacon Collection response that correspond to a Resource descr
  "query": {
       "filters": [
         {
-          "id": "description",
-          "value": "%genome comparison%",
-          "operator": "="
-          
+          "id": "ordo:Orphanet_730"
         },
         {
-          "id": "resourceTypes",
-          "value": " BiobankDataset",
-          "operator": "="
+          "id": "rdf:type",
+          "operator": "=",
+          "value": "ejprd:Biobank"
 
         }
       ],
-      "requestedGranularity": "count"
+      "requestedGranularity": "record"
     }
 }
 ```
 
+The following is an example response 
+
 **EXAMPLE /catalogs RESPONSE**
 ```JSON
 {
-  "meta":{
-      "apiVersion": "v2.0",
-      "beaconId": "Unique Beacon ID in reverse domain name notation",
-      "returnedGranularity":"record"
-  },
-  "responseSummary": 
-  {
-    "exists": true,
-    "numTotalResults": 1
-  },
-  "response": {
-    "resultSets": [
-      {
-        "resultsCount": 1,
-        "results": [
-          {
-          "createDateTime": "2017-04-30T00:00:00+00:00",
-          "description": "The Genome in a Bottle Consortium, hosted by the National Institute of Standards and Technology (NIST) is creating reference materials and data for human genome sequencing, as well as methods for genome comparison and benchmarking. ",
-          "externalUrl": "https://www.nature.com/articles/sdata201625, https://jimb.stanford.edu/giab-resources",
-          "id": "EGAD00001008097",
-          "name": "The Genome in a Bottle Consortium (GIAB)",
-          "updateDateTime": "2017-04-30T00:00:00+00:00",
-          "resourceTypes": ["BiobankDataset"],
-          "organisation": ["UOL"]
-          }
+    "meta": {
+        "beaconId": "ejprd.beacon.directory.bbmri-eric.eu",
+        "apiVersion": "v2.0.0",
+        "returnedGranularity": "record",
+        "receivedRequestSummary": {
+            "apiVersion": "2.0",
+            "requestedSchemas": [],
+            "filters": [
+                {
+                    "id": "ordo:Orphanet_730"
+                },
+                {
+                "id": "rdf:type",
+                "operator": "=",
+                "value": "ejprd:Biobank"
+
+                }
+            ],
+            "requestParameters": {},
+            "includeResultsetResponses": "HIT",
+            "pagination": {
+                "skip": 0,
+                "limit": 50
+            },
+            "requestedGranularity": "record",
+            "testMode": false
+        },
+        "returnedSchemas": [
+            {
+                "entityType": "resources",
+                "schema": "ejprd-resources-v1.0.0",
+                "name": "EJPRD schema for resources",
+                "url": "https://raw.githubusercontent.com/ejp-rd-vp/vp-api-specs/main/versions/schemas/biboank-registry-schema.json",
+                "version": "v1.0.0"
+            }
         ]
-      }
-    ]
-  }
- }
+    },
+    "responseSummary": {
+        "exists": true,
+        "numTotalResults": 1
+    },
+    "beaconHandovers": [],
+    "response": {
+        "resultSets": [
+            {
+                "resultsCount": 1,
+                "results": [{
+                    "@context": "https://raw.githubusercontent.com/ejp-rd-vp/vp-api-specs/main/versions/json-ld-contexts/ejprd-context.json",
+                    "@id": "biobank-1:collection:collection-1",
+                    "@type": "ejprd:Biobank",
+                    "title": "Rare Disease Biobank",
+                    "logo": "http://raredisease.biobanl.eu/logo.png",
+                    "description": "Rare disease biobank with data about muscular distrophy",
+                    "populationCoverage": "European",
+                    "theme": "ordo:Orphanet_730",
+                    "vpConnection": "ejprd:VPContentDiscovery",
+                    "landingPage": "http://biobank.raredisease.org",
+                    "personalData": "true",
+                    "publisher": {
+                        "title": "Biobank hosting collection",
+                        "description": "The biobank that hosts the collection",
+                        "location": {
+                            "title": "Italy Cagliari",
+                            "description": "Via Mario Rossi"
+                        }
+                    },
+                    "language": "EN"
+                }]
+            }
+        ]
+    }
+}
 ```
 
 [ ^ Back to the top](#top)

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ In this work, we present API specification for querying RD patient registries, b
       * [Example request & response](#individuals-example)
       * [Understanding the response with ranges](#threshold-ranges)
          * [Ranges example](#response-range-example)
+    * [Biosamples endpoint](#biosamples)
+      * [List of filters](#biosamples-filters)
+      * [Filters description](#biosamples-filters-description)
+      * [Example request & response](#biosamples-example)
     * [Catalogs endpoint](#catalogs)
       * [List of filters](#catalogs-filters)
       * [Filters description](#catalogs-filters-description)
@@ -318,6 +322,144 @@ To provide flexibility for implementers between using a range, the "info" sectio
 In this example, the result could be a count of individuals between 71 to 80 (the resource only responds with ranges of size 10).
 
 [ ^ Back to the top](#top)
+
+<hr>
+
+<h3 id="biosamples"> Biosamples endpoint </h3>
+
+[/biosamples](https://github.com/ejp-rd-vp/vp-api-specs/blob/main/individuals_api_v0.2.yml) endpoint returns the **__count of biosamples__** from a RD resource. Filters are provided as a part of the body while using a POST request to query resources.
+
+> Method: POST
+
+<h4 id="biosamples-filters"> List of filters and permitted values for the biosamples endpoint </h4>
+
+> **Note**: Elements within arrays in **value** fields are treated as **ORs**
+
+<table>
+<thead>
+        <th>CDE Concept</th>
+        <th>CDE Term</th>
+        <th>Beacon Filter Type</th>
+        <th>ID</th>
+        <th>Operator</th>
+        <th>Permitted Values</th>
+</thead>
+<tbody>
+    <tr>
+        <td rowspan="5">
+            <b>Sex</b>
+        </td>
+        <td rowspan="5">
+            obo:NCIT_C28421
+        </td>
+        <td rowspan="5">
+            Alphanumerical
+        </td>
+        <td rowspan="5">
+            NCIT_C28421
+        </td>
+        <td rowspan="5">
+            =
+        </td>
+        <td>
+            NCIT_C16576
+        </td>
+    </tr>
+    <tr>
+        <td>
+            NCIT_C20197
+        </td>
+    </tr>
+    <tr>
+        <td>
+            NCIT_C124294
+        </td>
+    </tr>
+    <tr>
+        <td>
+            NCIT_C17998
+        </td>
+    </tr>
+    <tr>
+        <td>
+            An array of any of the above
+        </td>
+    </tr>
+    <tr>
+        <td><b>Disease or Disorder</b></td>
+        <td>obo:NCIT_C2991</td>
+        <td>Ontology</td>
+        <td>A single value or an array of orphanet terms. <b>e.g. Orphanet_558 or [Orphanet_558, Orphanet_773]</b></td>
+        <td colspan="2">NA</td>
+    </tr>
+    <tr>
+        <td><b>Sample Material Type</b></td>
+        <td>obo:NCIT_C70713</td>
+        <td>Custom</td>
+        <td>
+
+A single value or an array of values from [here](https://samply.github.io/bbmri-fhir-ig/CodeSystem-SampleMaterialType.html)
+        </td>
+        <td colspan="2">NA</td>
+    </tr>
+</tbody>
+</table>
+
+<h3 id="biosamples-filters-description"> Biosamples Filters Description </h3>
+
+**Sex**: The biological sex of the biosample.
+
+**Disease or Disorder**: TBD
+
+**Sample Material Type**: The type of material of the biosample. 
+
+[ ^ Back to the top](#top)
+
+<hr>
+
+<h3> An example request & response to query for biosamples is shown below: </h3>
+
+<h5 id="biosamples-example">EXAMPLE /biosamples REQUEST </h5>
+
+```JSON
+{
+  "meta": {
+    "apiVersion": "v2.0"
+  },
+  "query": {
+    "filters": [
+      {
+        "id": "obo:NCIT_C28421",
+        "operator": "=",
+        "value": "obo:NCIT_C16576"
+      }
+    ]
+  }
+}
+```
+
+**EXAMPLE /biosamples RESPONSE**
+
+
+```JSON
+{
+  "responseSummary": {
+    "exists": true,
+    "numTotalResults": 381
+  },
+  "beaconHandovers": [
+    {
+      "handoverType": {
+        "id": "CUSTOM",
+        "label": "Project description"
+      },
+      "note": "Project description",
+      "url": ""
+    }
+  ]
+}
+```
+The filter **SHOULD** be one of the terms from the [filters and permitted values table](#biosamplse). Please note that not all resources will support all of the filters. In such cases the response should include a [warning message in the 'info' part](#warning-response-example) indicating which requested filters are unsupported and these were not included in the query.
 
 <hr>
 

--- a/examples/biobank.json
+++ b/examples/biobank.json
@@ -1,0 +1,22 @@
+{
+    "@context": "https://raw.githubusercontent.com/ejp-rd-vp/vp-api-specs/main/versions/json-ld-contexts/ejprd-context.json",
+    "@id": "biobank-1:collection:collection-1",
+    "@type": "ejprd:Biobank",
+    "title": "Rare Disease Biobank",
+    "logo": "http://raredisease.biobanl.eu/logo.png",
+    "description": "Rare disease biobank with data about muscular distrophy",
+    "populationCoverage": "European",
+    "theme": "ordo:Orphanet_730",
+    "vpConnection": "ejprd:VPContentDiscovery",
+    "landingPage": ["http://biobank.raredisease.org"],
+    "personalData": "true",
+    "publisher": {
+        "title": "Biobank hosting collection",
+        "description": "The biobank that hosts the collection",
+        "location": {
+            "title": "Italy Cagliari",
+            "description": "Via Mario Rossi"
+        }
+    },
+    "language": "EN"
+}

--- a/json-ld-contexts/ejprd-context.json
+++ b/json-ld-contexts/ejprd-context.json
@@ -5,6 +5,8 @@
         "dcat": "http://www.w3.org/ns/dcat#",
         "ejprd": "http://purl.org/ejp-rd/vocabulary/",
         "foaf": "http://xmlns.com/foaf/0.1/",
+        "sio": "http://semanticscience.org/resource/",
+        "odrl": "https://www.w3.org/TR/odrl-model/",
         "title": {
             "@id": "dct:title",
             "@type": "xsd:string"
@@ -67,6 +69,10 @@
         },
         "spatial": {
             "@id": "dct:spatial"
+        },
+        "isRelatedTo": {
+            "@id": "sio:SIO_000001",
+            "@type": "@id"
         }
     }
 }

--- a/json-ld-contexts/ejprd-context.json
+++ b/json-ld-contexts/ejprd-context.json
@@ -1,0 +1,69 @@
+{
+    "@context": {
+        "xsd": "http://www.w3.org/2001/XMLSchema#",
+        "dct": "http://purl.org/dc/terms/",
+        "dcat": "http://www.w3.org/ns/dcat#",
+        "ejprd": "http://purl.org/ejp-rd/vocabulary/",
+        "foaf": "http://xmlns.com/foaf/0.1/",
+        "title": {
+            "@id": "dct:title",
+            "@type": "xsd:string"
+        },
+        "logo": {
+            "@id": "foaf:logo",
+            "type": "@id"
+        },
+        "description": {
+            "@id": "dct:title",
+            "@type": "xsd:string"
+        },
+        "populationCoverage": {
+            "@id": "ejprd:populationCoverage",
+            "@type": "xsd:string"
+        },
+        "theme": {
+            "@id": "dcat:theme",
+            "@type": "@id"
+        },
+        "publisher": {
+            "@id": "dct:publisher",
+            "@type": "foaf:Organization"
+        },
+        "license": {
+            "@id": "dct:license",
+            "@type": "@id"
+        },
+        "personalData": {
+            "@id": "ejprd:personalData",
+            "@type": "xsd:string"
+        },
+        "conformsTo": {
+            "@id": "dct:conformsTo",
+            "@type": "@id"
+        },
+        "vpConnection": {
+            "@id": "ejprd:vpConnection",
+            "@type": "@id"
+        },
+        "landingPage": {
+            "@id": "dcat:landingPage",
+            "@type": "@id"
+        },
+        "keyword": {
+            "@id": "dcat:keyword",
+            "@type": "xsd:string"
+        },
+        "language": {
+            "@id": "dct:language",
+            "@type": "xsd:string"
+        },
+        "accessRights": {
+            "@id": "dct:accessRights",
+            "@type": "@id"
+        },
+        "hasPolicy": {
+            "@id": "odrl:hasPolicy",
+            "@type": "@id"
+        }
+    }
+}

--- a/json-ld-contexts/ejprd-context.json
+++ b/json-ld-contexts/ejprd-context.json
@@ -64,6 +64,9 @@
         "hasPolicy": {
             "@id": "odrl:hasPolicy",
             "@type": "@id"
+        },
+        "spatial": {
+            "@id": "dct:spatial"
         }
     }
 }

--- a/schemas/biobank-registry-schema.json
+++ b/schemas/biobank-registry-schema.json
@@ -8,7 +8,7 @@
             "type": "string",
             "format": "uri",
             "description": "The EJPRD context (i.e, JSON-LD context) containing the semantic definition of the properties in this schema",
-            "const": "https://raw.githubusercontent.com/ejp-rd-vp/query_builder_api/feat/beacon_version/versions/beacon/json-ld-contexts/ejprd-context.json"
+            "const": "https://raw.githubusercontent.com/ejp-rd-vp/vp-api-specs/main/versions/json-ld-contexts/ejprd-context.json"
         },
         "@id": {
             "type": "string",
@@ -65,7 +65,7 @@
         },
         "publisher": {
             "type": "object",
-            "$ref": "./organization-schema.json"
+            "$ref": "https://raw.githubusercontent.com/ejp-rd-vp/vp-api-specs/main/schemas/organization-schema.json"
         },
         "license": {
             "type": "string",

--- a/schemas/biobank-registry-schema.json
+++ b/schemas/biobank-registry-schema.json
@@ -1,0 +1,142 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "description": "A resource available in the catalog",
+    "$comment": "EJPRD Resource Resource Metadata Schema",
+    "type": "object",
+    "properties": {
+        "@context": {
+            "type": "string",
+            "format": "uri",
+            "description": "The EJPRD context (i.e, JSON-LD context) containing the semantic definition of the properties in this schema",
+            "const": "https://raw.githubusercontent.com/ejp-rd-vp/query_builder_api/feat/beacon_version/versions/beacon/json-ld-contexts/ejprd-context.json"
+        },
+        "@id": {
+            "type": "string",
+            "description": "Unique identifier of the resource. It has the same meaning as @id in JSON-LD"
+        },
+        "@type": {
+            "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/definitions/CURIE",
+            "description": "The type of resource. It must be one of ejprd:Biobank, ejprd:PatientRegistry, ejprd:Guideline, dcat:Dataset",
+            "enum": [
+                "ejprd:Biobank",
+                "ejprd:PatientRegistry",
+                "ejprd:Guideline",
+                "dcat:Dataset"
+            ],
+            "examples": [
+                "ejprd:Biobank"
+            ]
+        },
+        "title": {
+            "type": "string",
+            "description": "The name of the resource. (required)",
+            "examples": [
+                "Bank of muscular disease"
+            ]
+        },
+        "logo": {
+            "type": "string",
+            "format": "uri",
+            "description": "A link to a graphic representation of the resource (optional)"
+        },
+        "description": {
+            "type": "string",
+            "description": "The description of the resource (optional)"
+        },
+        "populationCoverage": {
+            "type": "string",
+            "description": "Gives an indication of the part of the population covered by this biobank/patient registry. (required)",
+            "enum": [
+                "National",
+                "International",
+                "Regional",
+                "European"
+            ]
+        },
+        "theme": {
+            "type": "array",
+            "items": {
+                "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/definitions/CURIE"
+            },
+            "description": "A list of concepts that this resource deals with. It has to be an IRI represented as CURIE. (required)",
+            "examples": [
+                "ordo:Orphanet_730"
+            ]
+        },
+        "publisher": {
+            "type": "object",
+            "$ref": "./organization-schema.json"
+        },
+        "license": {
+            "type": "string",
+            "format": "uri",
+            "description": "This should contain a URL that provides details regarding the license that is applicable to this resource (required)"
+        },
+        "personalData": {
+            "type": "string",
+            "description": "Whether the resource handles personal data or not",
+            "enum": [
+                "true",
+                "false"
+            ]
+        },
+        "conformsTo": {
+            "type": "string",
+            "format": "uri",
+            "description": "If applicable, it should point to the IRI an established standard to which the described resource conforms (recommended)"
+        },
+        "vpConnection": {
+            "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/definitions/CURIE",
+            "description": "Tells the EJP RD Virtual Platform whether content of this resource is discoverable or whether the resource is discoverable (required)",
+            "examples": [
+                "ejprd:VPContentDiscovery"
+            ]
+        },
+        "landingPage": {
+            "type": "string",
+            "format": "uri",
+            "description": "A Web page that can be navigated to in a Web browser to gain access to the resource (optional)"
+        },
+        "keyword": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "description": "A list of keywords applicable to this resource (optional)"
+        },
+        "language": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "examples": [
+                "IT",
+                "EN"
+            ],
+            "description": "A list of ISO 639-1 two-letter codes for the languages this resource is provided (required)"
+        },
+        "accessRights": {
+            "type": "string",
+            "format": "uri",
+            "description": "Information about who can access the resource or an indication of its security status. This should point to a URL where this information can be found (recommended)"
+        },
+        "hasPolicy": {
+            "type": "string",
+            "format": "uri",
+            "description": "An ODRL conformant policy expressing the rights associated with the resource (recommended)"
+        }
+    },
+    "required": [
+        "@context",
+        "@id",
+        "@type",
+        "title",
+        "populationCoverage",
+        "theme",
+        "vpConnection",
+        "license",
+        "language",
+        "personalData"
+    ],
+    "additionalProperties": true
+}

--- a/schemas/biobank-registry-schema.json
+++ b/schemas/biobank-registry-schema.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "description": "A resource available in the catalog",
-    "$comment": "EJPRD Resource Resource Metadata Schema",
+    "description": "A biobank or patient registry available in the catalog",
+    "$comment": "EJPRD Beacon Schema for Biobank and PatientRegistry",
     "type": "object",
     "properties": {
         "@context": {
@@ -19,9 +19,7 @@
             "description": "The type of resource. It must be one of ejprd:Biobank, ejprd:PatientRegistry, ejprd:Guideline, dcat:Dataset",
             "enum": [
                 "ejprd:Biobank",
-                "ejprd:PatientRegistry",
-                "ejprd:Guideline",
-                "dcat:Dataset"
+                "ejprd:PatientRegistry"
             ],
             "examples": [
                 "ejprd:Biobank"
@@ -93,9 +91,12 @@
             ]
         },
         "landingPage": {
-            "type": "string",
-            "format": "uri",
-            "description": "A Web page that can be navigated to in a Web browser to gain access to the resource (optional)"
+            "type": "array",
+            "items": {
+                "type": "string",
+                "format": "uri",
+                "description": "One or more web pages that can be navigated to in a Web browser to gain access to the resource (optional)"
+            }
         },
         "keyword": {
             "type": "array",

--- a/schemas/dataset.json
+++ b/schemas/dataset.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "description": "A guideline available in the catalog",
-    "$comment": "EJPRD Beacon Schema for Guideline",
+    "description": "A guideline available in the dataset",
+    "$comment": "EJPRD Beacon Schema for Dataset",
     "type": "object",
     "properties": {
         "@context": {
@@ -12,30 +12,30 @@
         },
         "@id": {
             "type": "string",
-            "description": "Unique identifier of the guideline. It has the same meaning as @id in JSON-LD"
-        }, 
+            "description": "Unique identifier of the dataset. It has the same meaning as @id in JSON-LD"
+        },
         "@type": {
             "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/definitions/CURIE",
-            "description": "The type of resource. It must be ejprd:Guideline (required)",
+            "description": "The type of resource. It must be one of dcat:Dataset",
             "enum": [
-                "ejprd:Guideline"
+                "dcat:Dataset"
             ],
             "examples": [
-                "ejprd:Guideline"
+                "dcat:Dataset"
             ]
         },
         "title": {
             "type": "string",
-            "description": "The name of the guideline. (required)"
+            "description": "The name of the dataset. (required)"
         },
         "logo": {
             "type": "string",
             "format": "uri",
-            "description": "A link to a graphic representation of the guidline (optional)"
+            "description": "A link to a graphic representation of the dataset (optional)"
         },
         "description": {
             "type": "string",
-            "description": "The description of the resource (optional)"
+            "description": "The description of the dataset (optional)"
         },
         "theme": {
             "type": "array",
@@ -45,6 +45,20 @@
             "description": "A list of concepts that this resource deals with. It has to be an IRI represented as CURIE. (required)",
             "examples": [
                 "ordo:Orphanet_730"
+            ]
+        },
+        "keyword": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "description": "A list of keywords applicable to this dataset (optional)"
+        },
+        "hasVersion": {
+            "type": "string",
+            "description": "Where applicable, it should provide the version as a string of text.",
+            "examples": [
+                "4.2.1"
             ]
         },
         "publisher": {
@@ -104,6 +118,10 @@
             "type": "string",
             "format": "uri",
             "description": "An ODRL conformant policy expressing the rights associated with the resource (recommended)"
+        },
+        "isRelatedTo": {
+            "type": "string",
+            "description": "When the dataset refers to a biobank or patient registry, it should contain the title of it (optional)"
         }
     },
     "required": [

--- a/schemas/guideline.json
+++ b/schemas/guideline.json
@@ -1,0 +1,124 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "description": "A guideline available in the catalog",
+    "$comment": "EJPRD Beacon Schema for Guideline",
+    "type": "object",
+    "properties": {
+        "@context": {
+            "type": "string",
+            "format": "uri",
+            "description": "The EJPRD context (i.e, JSON-LD context) containing the semantic definition of the properties in this schema",
+            "const": "https://raw.githubusercontent.com/ejp-rd-vp/vp-api-specs/main/versions/json-ld-contexts/ejprd-context.json"
+        },
+        "@id": {
+            "type": "string",
+            "description": "Unique identifier of the resource. It has the same meaning as @id in JSON-LD"
+        },
+        "@type": {
+            "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/definitions/CURIE",
+            "description": "The type of resource. It must be one of ejprd:Biobank, ejprd:PatientRegistry, ejprd:Guideline, dcat:Dataset",
+            "enum": [
+                "ejprd:Guideline"
+            ],
+            "examples": [
+                "ejprd:Guideline"
+            ]
+        },
+        "title": {
+            "type": "string",
+            "description": "The name of the resource. (required)",
+            "examples": [
+                "Bank of muscular disease"
+            ]
+        },
+        "logo": {
+            "type": "string",
+            "format": "uri",
+            "description": "A link to a graphic representation of the resource (optional)"
+        },
+        "description": {
+            "type": "string",
+            "description": "The description of the resource (optional)"
+        },
+        "theme": {
+            "type": "array",
+            "items": {
+                "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/definitions/CURIE"
+            },
+            "description": "A list of concepts that this resource deals with. It has to be an IRI represented as CURIE. (required)",
+            "examples": [
+                "ordo:Orphanet_730"
+            ]
+        },
+        "publisher": {
+            "type": "object",
+            "$ref": "https://raw.githubusercontent.com/ejp-rd-vp/vp-api-specs/main/schemas/organization-schema.json"
+        },
+        "license": {
+            "type": "string",
+            "format": "uri",
+            "description": "This should contain a URL that provides details regarding the license that is applicable to this resource (required)"
+        },
+        "personalData": {
+            "type": "string",
+            "description": "Whether the resource handles personal data or not",
+            "enum": [
+                "true",
+                "false"
+            ]
+        },
+        "conformsTo": {
+            "type": "string",
+            "format": "uri",
+            "description": "If applicable, it should point to the IRI an established standard to which the described resource conforms (recommended)"
+        },
+        "vpConnection": {
+            "$ref": "https://raw.githubusercontent.com/ga4gh-beacon/beacon-v2/main/framework/json/common/beaconCommonComponents.json#/definitions/CURIE",
+            "description": "Tells the EJP RD Virtual Platform whether content of this resource is discoverable or whether the resource is discoverable (required)",
+            "examples": [
+                "ejprd:VPContentDiscovery"
+            ]
+        },
+        "landingPage": {
+            "type": "array",
+            "items": {
+                "type": "string",
+                "format": "uri",
+                "description": "One or more web pages that can be navigated to in a Web browser to gain access to the resource (optional)"
+            }
+        },
+        "language": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "examples": [
+                "IT",
+                "EN"
+            ],
+            "description": "A list of ISO 639-1 two-letter codes for the languages this resource is provided (required)"
+        },
+        "accessRights": {
+            "type": "string",
+            "format": "uri",
+            "description": "Information about who can access the resource or an indication of its security status. This should point to a URL where this information can be found (recommended)"
+        },
+        "hasPolicy": {
+            "type": "string",
+            "format": "uri",
+            "description": "An ODRL conformant policy expressing the rights associated with the resource (recommended)"
+        }
+    },
+    "required": [
+        "@context",
+        "@id",
+        "@type",
+        "title",
+        "theme",
+        "vpConnection",
+        "license",
+        "language",
+        "personalData"
+    ],
+    "additionalProperties": true
+}

--- a/schemas/location-schema.json
+++ b/schemas/location-schema.json
@@ -1,0 +1,21 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "description": "An Organization as defined by the EJPRD Resource Metadata Schema",
+    "type": "object",
+    "properties": {
+        "title": {
+            "type": "string",
+            "description": "The name of the location (required)",
+            "examples": [
+                "Fraunhofer-Institut für Biomedizinische Technik (IBMT)"
+            ]
+        },
+        "description": {
+            "type": "string",
+            "description": "A description of the location. Typically this is the address.",
+            "examples": [
+                "Anna-Louisa-Karsch Str. 2, 10178 Berlin, Germany"
+            ]
+        }
+    }
+}

--- a/schemas/organization-schema.json
+++ b/schemas/organization-schema.json
@@ -1,0 +1,47 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "description": "An Organization as defined by the EJPRD Resource Metadata Schema",
+    "type": "object",
+    "properties": {
+        "@context": {
+            "type": "string",
+            "format": "uri",
+            "description": "The EJPRD context (i.e, JSON-LD context) containing the semantic definition of the properties in this schema",
+            "const": "https://raw.githubusercontent.com/ejp-rd-vp/vp-api-specs/feat/beacon_version/versions/beacon/json-ld-contexts/ejprd-context.json"
+        },
+        "@id": {
+            "type": "string",
+            "description": "Unique identifier of the organization"
+        },
+        "title": {
+            "type": "string",
+            "description": "The name of the organisation. (required)",
+            "examples": [
+                "Bank of muscular disease"
+            ]
+        },
+        "description": {
+            "type": "string",
+            "description": "Description of the resource"
+        },
+        "homepage": {
+            "type": "string",
+            "format": "uri",
+            "description": "URL to an external system providing more dataset information (RFC 3986 format)."
+        },
+        "logo": {
+            "type": "string",
+            "format": "uri",
+            "description": "A link to a graphic representation of the resource (optional)"
+        },
+        "location": {
+            "type": "object",
+            "@ref": "./location-schema.json"
+        }
+    },
+    "required": [
+        "@id",
+        "title",
+        "location"
+    ]
+}

--- a/schemas/organization-schema.json
+++ b/schemas/organization-schema.json
@@ -36,7 +36,7 @@
         },
         "location": {
             "type": "object",
-            "@ref": "./location-schema.json"
+            "@ref": "https://raw.githubusercontent.com/ejp-rd-vp/vp-api-specs/main/schemas/location-schema.json"
         }
     },
     "required": [

--- a/schemas/organization-schema.json
+++ b/schemas/organization-schema.json
@@ -34,7 +34,7 @@
             "format": "uri",
             "description": "A link to a graphic representation of the resource (optional)"
         },
-        "location": {
+        "spatial": {
             "type": "object",
             "@ref": "https://raw.githubusercontent.com/ejp-rd-vp/vp-api-specs/main/schemas/location-schema.json"
         }


### PR DESCRIPTION
This PR adds new schemas for the resources returned by the `catalogs` endpoint. 
The schema is compliant with the [resource metada schemas](https://github.com/ejp-rd-vp/resource-metadata-schema).
Currently, there are schemas for Biobank, Patient Registries, Guidelines, Dataset, Organization and Location.
The Dataservice for one of the resource is still needed.
The documentation has been changed accordingly